### PR TITLE
Add missing "await" to fix issue submission script

### DIFF
--- a/src/reporting/submit-issue.js
+++ b/src/reporting/submit-issue.js
@@ -75,7 +75,7 @@ if (require.main === module) {
 	execSync(`git pull origin main`);
 	console.log(`Saving updated report to ${filename}`);
 	metadata.Tracked = issueUrl;
-	fs.writeFile(filename, issueData.stringify(), 'utf-8');
+	await fs.writeFile(filename, issueData.stringify(), 'utf-8');
 	console.log(issueData.stringify());
 	execSync(`git add -u ${filename}`);
 	needsCommit = true;


### PR DESCRIPTION
The `writeFile` function is asynchronous, so need to be awaited otherwise the following git commands could well run on an empty file.

This should fix #211.