### PR TITLE
Add library to surface WebIDL issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "node-fetch": "^2.6.5",
         "node-pandoc": "0.3.0",
         "reffy": "^12.0.0",
-        "semver": "^7.3.5"
+        "semver": "^7.3.5",
+        "webidl2": "^24.2.2"
       },
       "bin": {
         "strudy": "strudy.js"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "node-fetch": "^2.6.5",
     "node-pandoc": "0.3.0",
     "reffy": "^12.0.0",
-    "semver": "^7.3.5"
+    "semver": "^7.3.5",
+    "webidl2": "^24.2.2"
   }
 }

--- a/src/cli/study-backrefs.js
+++ b/src/cli/study-backrefs.js
@@ -27,7 +27,8 @@
  * @module backrefs
  */
 
-const { loadCrawlResults, studyBackrefs } = require('../lib/study-backrefs');
+const { loadCrawlResults } = require('../lib/util');
+const { studyBackrefs } = require('../lib/study-backrefs');
 const path = require("path");
 
 function reportToConsole(results) {

--- a/src/lib/study-backrefs.js
+++ b/src/lib/study-backrefs.js
@@ -1,5 +1,3 @@
-const requireFromWorkingDirectory = require('../lib/require-cwd');
-const { expandCrawlResult } = require("reffy");
 const fetch = require("node-fetch");
 
 /**
@@ -218,28 +216,6 @@ const shortnameOfNonNormativeDocs = [
   "webrtc-interop-reports",
   "webrtc-nv-use-cases"
 ];
-async function loadCrawlResults(edCrawlResultsPath, trCrawlResultsPath) {
-  let edCrawlResults, trCrawlResults;
-  try {
-    edCrawlResults = requireFromWorkingDirectory(edCrawlResultsPath);
-  } catch(e) {
-    throw "Impossible to read " + edCrawlResultsPath + ": " + e;
-  }
-  try {
-    trCrawlResults = requireFromWorkingDirectory(trCrawlResultsPath);
-  } catch(e) {
-    throw "Impossible to read " + trCrawlResultsPath + ": " + e;
-  }
-
-  edCrawlResults = await expandCrawlResult(edCrawlResults, edCrawlResultsPath.replace(/index\.json$/, ''));
-  trCrawlResults = await expandCrawlResult(trCrawlResults, trCrawlResultsPath.replace(/index\.json$/, ''));
-
-  return {
-    ed: edCrawlResults.results,
-    tr: trCrawlResults.results
-  };
-}
-
 
 async function studyBackrefs(edResults, trResults = []) {
   trResults = trResults || [];
@@ -435,4 +411,4 @@ async function studyBackrefs(edResults, trResults = []) {
 /**************************************************
 Export methods for use as module
 **************************************************/
-module.exports = { studyBackrefs, loadCrawlResults };
+module.exports = { studyBackrefs };

--- a/src/lib/study-webidl.js
+++ b/src/lib/study-webidl.js
@@ -19,6 +19,7 @@ function recordAnomaly(spec, anomalyType, error) {
       noIdlExposure: [],
       duplicateIdlDefinition: [],
       unexpectedEventHandler: [],
+      singleEnumValue: [],
       wrongCaseEnumValue: []
     };
   }
@@ -42,6 +43,22 @@ function checkEventHandlers(spec, memberHolder, iface = memberHolder) {
     recordAnomaly(spec, "unexpectedEventHandler", `${iface.name} has an event handler ${eventHandler.name} but does not inherit from EventTarget`);
   }
 }
+
+function checkEnumMultipleValues(spec, idl) {
+  if (idl.values.length <= 1) {
+    recordAnomaly(spec, "singleEnumValue", `The ${idl.name} enum has fewer than 2 possible values`);
+  }
+}
+
+function checkSyntaxOfEnumValue(spec, idl) {
+  idl.values.forEach(({value}) => {
+    if (value.match(/[A-Z]_/)) {
+      recordAnomaly(spec, "wrongCaseEnumValue", `The value ${value} of  ${idl.name} enum does not match the expected conventions (lower case, hyphen separated words)`);
+    }
+  });
+}
+
+
 const specName = ({spec}) => spec.shortname;
 
 async function studyWebIdl(edResults) {
@@ -94,6 +111,10 @@ async function studyWebIdl(edResults) {
       switch(idl.type) {
       case "interface":
 	checkEventHandlers(spec, idl, mainDef);
+	break;
+      case "enum":
+	checkEnumMultipleValues(spec, idl);
+	checkSyntaxOfEnumValue(spec, idl);
 	break;
       }
     }

--- a/src/lib/study-webidl.js
+++ b/src/lib/study-webidl.js
@@ -1,0 +1,107 @@
+const { expandCrawlResult } = require("reffy");
+const fetch = require("node-fetch");
+const WebIDL2 = require("webidl2");
+
+const report = {};
+
+// DRY with study-backref
+function recordAnomaly(spec, anomalyType, error) {
+  if (!report[spec.url]) {
+    report[spec.url] = {
+      title: spec.title,
+      crawled: spec.crawled,
+      shortname: spec.shortname,
+      repo: spec.nightly.repository,
+      // specific to this report
+      invalidWebIdl: [],
+      idlNameReused: [],
+      noMainIdlDefinition: [],
+      noIdlExposure: [],
+      duplicateIdlDefinition: [],
+      unexpectedEventHandler: [],
+      wrongCaseEnumValue: []
+    };
+  }
+  report[spec.url][anomalyType].push(error);
+}
+
+const platformIdl = {};
+
+function inheritsFrom(iface, ancestor) {
+  if (!iface.inheritance) return false;
+  if (iface.inheritance === ancestor) return true;
+  const parentInterface = platformIdl[iface.inheritance].find(({idl}) => !idl.partial).idl;
+  return inheritsFrom(parentInterface, ancestor);
+}
+
+// TODO: a full check of event handlers would require:
+// - checking if the interface doesn't include a mixin with eventhandlers
+function checkEventHandlers(spec, memberHolder, iface = memberHolder) {
+  const eventHandler = memberHolder.members.find(m => m?.name?.startsWith("on") && m.type === "attribute" && m.idlType?.idlType === "EventHandler");
+  if (eventHandler && !inheritsFrom(iface, "EventTarget")) {
+    recordAnomaly(spec, "unexpectedEventHandler", `${iface.name} has an event handler ${eventHandler.name} but does not inherit from EventTarget`);
+  }
+}
+const specName = ({spec}) => spec.shortname;
+
+async function studyWebIdl(edResults) {
+  edResults.forEach(spec => {
+    if (!spec.idl) return;
+    let ast;
+    try {
+      ast = WebIDL2.parse(spec.idl);
+      for (let idlItem of ast) {
+	if (!platformIdl[idlItem.name]) {
+	  platformIdl[idlItem.name] = [];
+	}
+	platformIdl[idlItem.name].push({spec, idl: idlItem});
+      }
+    } catch (e) {
+      // TODO: load from curated?
+      recordAnomaly(spec, "invalidWebIdl", e.message);
+      return;
+    }
+  });
+  for (const name in platformIdl) {
+    const types = new Set(platformIdl[name].map(({idl}) => idl.type));
+    const specNames = platformIdl[name].map(specName);
+    if (types.size > 1) {
+      recordAnomaly(platformIdl[name][0].spec, "idlNameReused", `${name} is used as the IDL for different types: ${[...types].join(', ')} in ${specNames.join(', ')}`);
+      continue;
+    }
+    const type = [...types][0];
+    let mainDef;
+    const allowPartials = ["interface", "dictionary", "namespace", "interface mixin"];
+    const allowMultipleDefs = allowPartials.concat("includes");
+    if (!allowMultipleDefs.includes(type)) {
+      if (platformIdl[name].length > 1) {
+	recordAnomaly(platformIdl[name][0].spec, "duplicateIdlDefinition", `${name} is defined as ${type} in several specifications ${specNames.join(', ')}`);
+      } else {
+	mainDef = platformIdl[name][0].idl;
+      }
+    }
+    if (allowPartials.includes(type)) {
+      const mainDefs = platformIdl[name].filter(({idl}) => !idl.partial);
+      if (mainDefs.length === 0) {
+	recordAnomaly(platformIdl[name][0].spec, "noMainIdlDefinition", `${name} is only defined as partial ${type} (in specifications ${platformIdl[name].map(specName).join(', ')})`);
+	continue;
+      } else if (mainDefs.length > 1) {
+	recordAnomaly(platformIdl[name][0].spec, "duplicateIdlDefinition", `${name} is defined as non-partial ${type} in several specifications ${mainDefs.map(specName).join(', ')}`);
+      }
+      mainDef = mainDefs[0].idl;
+    }
+    for (let {spec, idl} of platformIdl[name]) {
+      switch(idl.type) {
+      case "interface":
+	checkEventHandlers(spec, idl, mainDef);
+	break;
+      }
+    }
+  }
+  return report;
+}
+
+/**************************************************
+Export methods for use as module
+**************************************************/
+module.exports = { studyWebIdl };

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,0 +1,31 @@
+const requireFromWorkingDirectory = require('../lib/require-cwd');
+const { expandCrawlResult } = require("reffy");
+
+async function loadCrawlResults(edCrawlResultsPath, trCrawlResultsPath) {
+  let edCrawlResults, trCrawlResults;
+  try {
+    edCrawlResults = requireFromWorkingDirectory(edCrawlResultsPath);
+  } catch(e) {
+    throw "Impossible to read " + edCrawlResultsPath + ": " + e;
+  }
+  edCrawlResults = await expandCrawlResult(edCrawlResults, edCrawlResultsPath.replace(/index\.json$/, ''));
+
+  if (trCrawlResultsPath) {
+    try {
+      trCrawlResults = requireFromWorkingDirectory(trCrawlResultsPath);
+    } catch(e) {
+      throw "Impossible to read " + trCrawlResultsPath + ": " + e;
+    }
+    trCrawlResults = await expandCrawlResult(trCrawlResults, trCrawlResultsPath.replace(/index\.json$/, ''));
+  }
+
+  return {
+    ed: edCrawlResults.results,
+    tr: trCrawlResults?.results
+  };
+}
+
+/**************************************************
+Export methods for use as module
+**************************************************/
+module.exports = { loadCrawlResults };

--- a/src/reporting/file-issue-for-review.js
+++ b/src/reporting/file-issue-for-review.js
@@ -2,7 +2,8 @@
    creates a draft of an issue per spec and per anomaly type
    and submits as a pull request in this repo if no existing one matches
 */
-const {studyBackrefs, loadCrawlResults} = require("../lib/study-backrefs");
+const { loadCrawlResults } = require('../lib/util');
+const {studyBackrefs } = require("../lib/study-backrefs");
 const path = require("path");
 const fs = require("fs").promises;
 const { execSync } = require('child_process');


### PR DESCRIPTION
This adds a library that can be used to create reports on WebIDL defects. It doesn't add the report creation yet.

I think ultimately, we would want these checks to be mostly a superset from the ones used in https://github.com/w3c/webref/tree/main/test/idl, and have the relevant checks imported from webref to enforce the package guarantees.

<details><summary>Output of running the checks on non-curated IDL</summary>
<pre>
{
  'https://registry.khronos.org/webgl/specs/latest/1.0/': {
    title: 'WebGL Specification',
    crawled: 'https://registry.khronos.org/webgl/specs/latest/1.0/',
    shortname: 'webgl1',
    repo: 'https://github.com/KhronosGroup/WebGL',
    invalidWebIdl: [
      'Syntax error at line 514, since `interface mixin WebGLRenderingContextBase`:\n' +
        '    attribute PredefinedColorSpace drawingBufferColorSpace = "srgb";\n' +
        '                                                           ^ Unterminated attribute, expected `;`'
    ],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [],
    wrongCaseEnumValue: []
  },
  'https://www.w3.org/TR/DOM-Level-2-Style/': {
    title: 'Document Object Model (DOM) Level 2 Style Specification',
    crawled: 'https://www.w3.org/TR/DOM-Level-2-Style/',
    shortname: 'DOM-Level-2-Style',
    repo: undefined,
    invalidWebIdl: [
      'Syntax error at line 15, since `interface StyleSheetList`:\n' +
        '  StyleSheet         item(in unsigned long index)\n' +
        '                          ^ Unterminated operation'
    ],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [],
    wrongCaseEnumValue: []
  },
  'https://fetch.spec.whatwg.org/': {
    title: 'Fetch Standard',
    crawled: 'https://fetch.spec.whatwg.org/',
    shortname: 'fetch',
    repo: 'https://github.com/whatwg/fetch',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [ 'The RequestDuplex enum has fewer than 2 possible values' ],
    wrongCaseEnumValue: []
  },
  'https://www.w3.org/TR/media-source-2/': {
    title: 'Media Source Extensions™',
    crawled: 'https://w3c.github.io/media-source/',
    shortname: 'media-source-2',
    repo: 'https://github.com/w3c/media-source',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [
      'partial interface AudioTrack exposure (Window,DedicatedWorker) is incompatible with main exposure (Window)',
      'partial interface VideoTrack exposure (Window,DedicatedWorker) is incompatible with main exposure (Window)',
      'partial interface TextTrack exposure (Window,DedicatedWorker) is incompatible with main exposure (Window)'
    ],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [],
    wrongCaseEnumValue: []
  },
  'https://html.spec.whatwg.org/multipage/': {
    title: 'HTML Standard',
    crawled: 'https://html.spec.whatwg.org/multipage/',
    shortname: 'html',
    repo: 'https://github.com/whatwg/html',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [
      'MessageEventSource is defined as typedef in several specifications html, portals'
    ],
    unexpectedEventHandler: [],
    singleEnumValue: [],
    wrongCaseEnumValue: []
  },
  'https://streams.spec.whatwg.org/': {
    title: 'Streams Standard',
    crawled: 'https://streams.spec.whatwg.org/',
    shortname: 'streams',
    repo: 'https://github.com/whatwg/streams',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [
      'The ReadableStreamReaderMode enum has fewer than 2 possible values',
      'The ReadableStreamType enum has fewer than 2 possible values'
    ],
    wrongCaseEnumValue: []
  },
  'https://w3c.github.io/gamepad/extensions.html': {
    title: 'Gamepad Extensions',
    crawled: 'https://w3c.github.io/gamepad/extensions.html',
    shortname: 'gamepad-extensions',
    repo: 'https://github.com/w3c/gamepad',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [
      'The GamepadHapticEffectType enum has fewer than 2 possible values'
    ],
    wrongCaseEnumValue: []
  },
  'https://wicg.github.io/fenced-frame/': {
    title: 'Fenced frame',
    crawled: 'https://wicg.github.io/fenced-frame/',
    shortname: 'fenced-frame',
    repo: 'https://github.com/WICG/fenced-frame',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [ 'The OpaqueProperty enum has fewer than 2 possible values' ],
    wrongCaseEnumValue: []
  },
  'https://wicg.github.io/trust-token-api/': {
    title: 'Private State Token API',
    crawled: 'https://wicg.github.io/trust-token-api/',
    shortname: 'trust-token-api',
    repo: 'https://github.com/WICG/trust-token-api',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [
      'The TokenType enum has fewer than 2 possible values',
      'The TokenVersion enum has fewer than 2 possible values'
    ],
    wrongCaseEnumValue: []
  },
  'https://wicg.github.io/web-otp/': {
    title: 'WebOTP API',
    crawled: 'https://wicg.github.io/web-otp/',
    shortname: 'web-otp',
    repo: 'https://github.com/WICG/web-otp',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [
      'The OTPCredentialTransportType enum has fewer than 2 possible values'
    ],
    wrongCaseEnumValue: []
  },
  'https://www.w3.org/TR/compute-pressure/': {
    title: 'Compute Pressure Level 1',
    crawled: 'https://w3c.github.io/compute-pressure/',
    shortname: 'compute-pressure',
    repo: 'https://github.com/w3c/compute-pressure',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [ 'The PressureSource enum has fewer than 2 possible values' ],
    wrongCaseEnumValue: []
  },
  'https://www.w3.org/TR/window-placement/': {
    title: 'Multi-Screen Window Placement',
    crawled: 'https://w3c.github.io/window-placement/',
    shortname: 'window-placement',
    repo: 'https://github.com/w3c/window-placement',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [
      'Screen has an event handler onchange but does not inherit from EventTarget'
    ],
    singleEnumValue: [],
    wrongCaseEnumValue: []
  },
  'https://www.w3.org/TR/screen-wake-lock/': {
    title: 'Screen Wake Lock API',
    crawled: 'https://w3c.github.io/screen-wake-lock/',
    shortname: 'screen-wake-lock',
    repo: 'https://github.com/w3c/screen-wake-lock',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [ 'The WakeLockType enum has fewer than 2 possible values' ],
    wrongCaseEnumValue: []
  },
  'https://www.w3.org/TR/web-animations-1/': {
    title: 'Web Animations',
    crawled: 'https://drafts.csswg.org/web-animations-1/',
    shortname: 'web-animations-1',
    repo: 'https://github.com/w3c/csswg-drafts',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [
      'FillMode is defined as enum in several specifications web-animations-1, web-animations-2',
      'AnimationPlaybackEvent is defined as non-partial interface in several specifications web-animations-1, web-animations-2',
      'AnimationPlaybackEventInit is defined as non-partial dictionary in several specifications web-animations-1, web-animations-2'
    ],
    unexpectedEventHandler: [],
    singleEnumValue: [],
    wrongCaseEnumValue: []
  },
  'https://www.w3.org/TR/webaudio/': {
    title: 'Web Audio API',
    crawled: 'https://webaudio.github.io/web-audio-api/',
    shortname: 'webaudio',
    repo: 'https://github.com/WebAudio/web-audio-api',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [ 'The AudioSinkType enum has fewer than 2 possible values' ],
    wrongCaseEnumValue: []
  },
  'https://www.w3.org/TR/webauthn-3/': {
    title: 'Web Authentication: An API for accessing Public Key Credentials - Level',
    crawled: 'https://w3c.github.io/webauthn/',
    shortname: 'webauthn-3',
    repo: 'https://github.com/w3c/webauthn',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [
      'The PublicKeyCredentialType enum has fewer than 2 possible values'
    ],
    wrongCaseEnumValue: []
  },
  'https://www.w3.org/TR/webgpu/': {
    title: 'WebGPU',
    crawled: 'https://gpuweb.github.io/gpuweb/',
    shortname: 'webgpu',
    repo: 'https://github.com/gpuweb/gpuweb',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [
      'The GPUStorageTextureAccess enum has fewer than 2 possible values',
      'The GPUAutoLayoutMode enum has fewer than 2 possible values'
    ],
    wrongCaseEnumValue: []
  },
  'https://www.w3.org/TR/webrtc-encoded-transform/': {
    title: 'WebRTC Encoded Transform',
    crawled: 'https://w3c.github.io/webrtc-encoded-transform/',
    shortname: 'webrtc-encoded-transform',
    repo: 'https://github.com/w3c/webrtc-encoded-transform',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [
      'SFrameTransform has an event handler onerror but does not inherit from EventTarget'
    ],
    singleEnumValue: [],
    wrongCaseEnumValue: []
  },
  'https://www.w3.org/TR/webrtc/': {
    title: 'WebRTC: Real-Time Communication in Browsers',
    crawled: 'https://w3c.github.io/webrtc-pc/',
    shortname: 'webrtc',
    repo: 'https://github.com/w3c/webrtc-pc',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [ 'The RTCRtcpMuxPolicy enum has fewer than 2 possible values' ],
    wrongCaseEnumValue: []
  },
  'https://www.w3.org/TR/webvtt1/': {
    title: 'WebVTT: The Web Video Text Tracks Format',
    crawled: 'https://w3c.github.io/webvtt/',
    shortname: 'webvtt1',
    repo: 'https://github.com/w3c/webvtt',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [ 'The AutoKeyword enum has fewer than 2 possible values' ],
    wrongCaseEnumValue: []
  },
  'https://www.w3.org/TR/webxr/': {
    title: 'WebXR Device API',
    crawled: 'https://immersive-web.github.io/webxr/',
    shortname: 'webxr',
    repo: 'https://github.com/immersive-web/webxr',
    invalidWebIdl: [],
    idlNameReused: [],
    noMainIdlDefinition: [
      'WebGLContextAttributes is only defined as partial dictionary (in specifications webxr)',
      'WebGLRenderingContextBase is only defined as partial interface mixin (in specifications webxr)'
    ],
    noIdlExposure: [],
    incompatiblePartialIdlExposure: [],
    duplicateIdlDefinition: [],
    unexpectedEventHandler: [],
    singleEnumValue: [],
    wrongCaseEnumValue: []
  }
}
</pre>
</details>