### PR TITLE
Handle more cases of IDL type structures

### DIFF
--- a/src/lib/study-webidl.js
+++ b/src/lib/study-webidl.js
@@ -128,6 +128,11 @@ const knownExtAttrs = new Set([
   "WebGLHandlesContextLoss" // https://registry.khronos.org/webgl/specs/latest/1.0/##5.14
 ]);
 
+const listIdlTypes = type => {
+  if (Array.isArray(type)) return type.map(listIdlTypes).flat();
+  if (typeof type === "string") return [type];
+  return listIdlTypes(type.idlType);
+};
 
 async function studyWebIdl(edResults) {
   const report = [];              // List of anomalies to report
@@ -256,10 +261,13 @@ async function studyWebIdl(edResults) {
     dfn = dfn ?? node;
     for (const [key, value] of Object.entries(node)) {
       if (key === "idlType") {
-        if (!usedTypes[value.idlType]) {
-          usedTypes[value.idlType] = [];
-        }
-        usedTypes[value.idlType].push({ spec, idl: dfn });
+	const idlTypes = listIdlTypes(value);
+	for (const idlType of idlTypes) {
+          if (!usedTypes[idlType]) {
+            usedTypes[idlType] = [];
+          }
+          usedTypes[idlType].push({ spec, idl: dfn });
+	}
       }
       else if (key === "extAttrs" && Array.isArray(value)) {
         for (const extAttr of value) {

--- a/test/study-webidl.js
+++ b/test/study-webidl.js
@@ -291,6 +291,7 @@ dictionary MyShelf : MyHome { required boolean full; };
   attribute bool boolDoesNotExist;
   attribute MyBed bed;
   undefined doSomething(USVString name, MyUnknownType thing);
+  attribute (DOMString or sequence<UnknownInnerType>) table;
 };
 `);
     assert.deepEqual(report[0]?.name, 'unknownType');
@@ -299,7 +300,9 @@ dictionary MyShelf : MyHome { required boolean full; };
     assert.deepEqual(report[1].message, `Unknown type "MyBed" used in definition of "MyRoom"`);
     assert.deepEqual(report[2]?.name, 'unknownType');
     assert.deepEqual(report[2].message, `Unknown type "MyUnknownType" used in definition of "MyRoom"`);
-    assert.deepEqual(report.length, 3);
+    assert.deepEqual(report[3]?.name, 'unknownType');
+    assert.deepEqual(report[3].message, `Unknown type "UnknownInnerType" used in definition of "MyRoom"`);
+    assert.deepEqual(report.length, 4);
   });
 
 


### PR DESCRIPTION
This would otherwise detect erroneous "[Object object]" unknown types.