### PR TITLE
Use fallback from curated when hitting invalid IDL

### DIFF
--- a/src/lib/study-webidl.js
+++ b/src/lib/study-webidl.js
@@ -129,7 +129,7 @@ const knownExtAttrs = new Set([
 ]);
 
 
-async function studyWebIdl(edResults) {
+async function studyWebIdl(edResults, curatedResults) {
   const report = [];              // List of anomalies to report
   const dfns = {};                // Index of IDL definitions (save includes)
   const includesStatements = {};  // Index of "includes" statements
@@ -289,7 +289,14 @@ async function studyWebIdl(edResults) {
       }
       catch (e) {
         recordAnomaly(spec, "invalid", e.message);
-        return { spec };
+	// Use fallback from curated version if available
+	// This avoids reporting errors e.g. of not-really unknown interfaces
+	try {
+	  const ast = WebIDL2.parse(curatedResults.find(s => s.url === spec.url).idl);
+	  return { spec, ast };
+	} catch (e) {
+          return { spec };
+	}
       }
     })
 

--- a/test/study-webidl.js
+++ b/test/study-webidl.js
@@ -43,6 +43,23 @@ interface Invalid;
     assert.deepEqual(report[0].specs[0].url, specUrl);
   });
 
+  it('reports invalid IDL and uses fallback from curated', async () => {
+    const crawlResult = toCrawlResult(`
+[Global=Window,Exposed=*]
+interface Invalid;
+`).concat(toCrawlResult(`
+[Global=Window,Exposed=*]
+interface Valid: Invalid {};
+`, specUrl2));
+    const curatedResult = toCrawlResult(`
+[Global=Window,Exposed=*]
+interface Invalid{};
+`);
+    const report = await studyWebIdl(crawlResult, curatedResult);
+    assert.deepEqual(report.length, 1);
+    assert.deepEqual(report[0]?.name, 'invalid');
+  });
+
 
   it('forgets about previous results', async () => {
     await analyzeIdl(`


### PR DESCRIPTION
Allows to skip errors about unknown interfaces