### PR TITLE
Lint most files and fix missing "fetch" requires

### DIFF
--- a/src/cli/study-webidl.js
+++ b/src/cli/study-webidl.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+const { loadCrawlResults } = require('../lib/util');
+const { studyWebIdl } = require('../lib/study-webidl');
+const requireFromWorkingDirectory = require('../lib/require-cwd');
+const { expandCrawlResult } = require("reffy");
+const path = require("path");
+
+
+function reportToConsole(results) {
+  results.forEach(anomaly => anomaly.specs = anomaly.specs.map(spec => {
+    return { shortname: spec.shortname, url: spec.url };
+  }));
+  console.log(JSON.stringify(results, null, 2));
+}
+
+async function main(crawlPath) {
+  // Target the index file if needed
+  if (!crawlPath.endsWith('index.json')) {
+    crawlPath = path.join(crawlPath, 'index.json');
+  }
+
+  let crawl;
+  try {
+    crawl = requireFromWorkingDirectory(crawlPath);
+  }
+  catch(e) {
+    throw "Impossible to read " + crawlPath + ": " + e;
+  }
+
+  const expanded = await expandCrawlResult(crawl, crawlPath.replace(/index\.json$/, ''), 'idl');
+  const report = studyWebIdl(expanded.results);
+  reportToConsole(report);
+}
+
+/**************************************************
+Code run if the code is run as a stand-alone module
+**************************************************/
+if (require.main === module) {
+  const crawlPath = process.argv[2];
+  
+  if (!crawlPath) {
+    console.error('Web IDL analyzer must be called with a paths to crawl results as first parameter');
+    process.exit(2);
+  }
+
+  main(crawlPath).catch(e => {
+    console.error(e);
+    process.exit(3);
+  });
+}

--- a/src/lib/canonicalize-url.js
+++ b/src/lib/canonicalize-url.js
@@ -8,42 +8,40 @@
  * to canonicalize dated W3C URLs to the Latest version, and to use a list of
  * equivalent URLs (that the crawler typically generates).
  */
-function canonicalizeUrl(url, options = {}) {
-    // Same code as in Reffy:
-    // https://github.com/w3c/reffy/blob/841db672190cf28658c29de3b8d7b8e28687ef47/src/postprocessing/annotate-links.js#L8-L19
-    let canon = url.replace(/^http:/, 'https:')
-            .split('#')[0]
-            .replace('index.html', '')
-            .replace('Overview.html', '')
-            .replace('cover.html', '')
-            .replace(/spec.whatwg.org\/.*/, 'spec.whatwg.org/')  // subpage to main document in whatwg
-            .replace(/w3.org\/TR\/(([^\/]+\/)+)[^\/]+\.[^\/]+$/, 'w3.org/TR/$1') // subpage to main document in w3c
-            .replace(/w3.org\/TR\/([^\/]+)$/, 'w3.org/TR/$1/') // enforce trailing slash
-            .replace(/w3c.github.io\/([^\/]+)$/, 'w3c.github.io/$1/') // enforce trailing slash for ED on GitHub
-        ;
+function canonicalizeUrl (url, options = {}) {
+  // Same code as in Reffy:
+  // https://github.com/w3c/reffy/blob/841db672190cf28658c29de3b8d7b8e28687ef47/src/postprocessing/annotate-links.js#L8-L19
+  let canon = url.replace(/^http:/, 'https:')
+    .split('#')[0]
+    .replace('index.html', '')
+    .replace('Overview.html', '')
+    .replace('cover.html', '')
+    .replace(/spec.whatwg.org\/.*/, 'spec.whatwg.org/') // subpage to main document in whatwg
+    .replace(/w3.org\/TR\/(([^/]+\/)+)[^/]+\.[^/]+$/, 'w3.org/TR/$1') // subpage to main document in w3c
+    .replace(/w3.org\/TR\/([^/]+)$/, 'w3.org/TR/$1/') // enforce trailing slash
+    .replace(/w3c.github.io\/([^/]+)$/, 'w3c.github.io/$1/') // enforce trailing slash for ED on GitHub
+    ;
 
-    if (options.datedToLatest) {
-        canon = canon.replace(
-            /w3.org\/TR\/[0-9]{4}\/[A-Z]+-(.*)-[0-9]{8}\/?/,
-            'w3.org/TR/$1/');
-    }
+  if (options.datedToLatest) {
+    canon = canon.replace(
+      /w3.org\/TR\/[0-9]{4}\/[A-Z]+-(.*)-[0-9]{8}\/?/,
+      'w3.org/TR/$1/');
+  }
 
-    let equivalentUrls = (options.equivalents) ? options.equivalents[canon] : null;
-    if (Array.isArray(equivalentUrls)) {
-        return (options.returnAlternatives ? equivalentUrls : equivalentUrls[0]);
-    }
-    else {
-        return (equivalentUrls ? equivalentUrls : canon);
-    }
+  const equivalentUrls = (options.equivalents) ? options.equivalents[canon] : null;
+  if (Array.isArray(equivalentUrls)) {
+    return (options.returnAlternatives ? equivalentUrls : equivalentUrls[0]);
+  } else {
+    return (equivalentUrls || canon);
+  }
 }
 
-
-function canonicalizesTo(url, refUrl, options = {datedToLatest: false, equivalents: null, returnAlternatives: true}) {
-    if (!url) return url;
-    let canon = canonicalizeUrl(url, options);
-    return Array.isArray(refUrl) ?
-        refUrl.some(u => canon.includes(u)) :
-        canon.includes(refUrl);
+function canonicalizesTo (url, refUrl, options = { datedToLatest: false, equivalents: null, returnAlternatives: true }) {
+  if (!url) return url;
+  const canon = canonicalizeUrl(url, options);
+  return Array.isArray(refUrl)
+    ? refUrl.some(u => canon.includes(u))
+    : canon.includes(refUrl);
 }
 
 module.exports = { canonicalizeUrl, canonicalizesTo };

--- a/src/lib/study-backrefs.js
+++ b/src/lib/study-backrefs.js
@@ -1,16 +1,15 @@
-const fetch = require("node-fetch");
-const { recordCategorizedAnomaly } = require("./util");
+const { recordCategorizedAnomaly } = require('./util');
 
 const possibleAnomalies = [
-  "brokenLinks",
-  "datedUrls",
-  "evolvingLinks",
-  "frailLinks",
-  "nonCanonicalRefs",
-  "notDfn",
-  "notExported",
-  "outdatedSpecs",
-  "unknownSpecs"
+  'brokenLinks',
+  'datedUrls',
+  'evolvingLinks',
+  'frailLinks',
+  'nonCanonicalRefs',
+  'notDfn',
+  'notExported',
+  'outdatedSpecs',
+  'unknownSpecs'
 ];
 
 /**
@@ -39,10 +38,10 @@ const matchSpecUrl = url =>
  TODO: DRY
  Copied from browser-specs/src/compute-shortname.js
 */
-function computeShortname(url) {
-  function parseUrl(url) {
+function computeShortname (url) {
+  function parseUrl (url) {
     // Handle /TR/ URLs
-    const w3cTr = url.match(/^https?:\/\/(?:www\.)?w3\.org\/TR\/([^\/]+)\/$/);
+    const w3cTr = url.match(/^https?:\/\/(?:www\.)?w3\.org\/TR\/([^/]+)\/$/);
     if (w3cTr) {
       return w3cTr[1];
     }
@@ -50,47 +49,46 @@ function computeShortname(url) {
     // Handle WHATWG specs
     const whatwg = url.match(/\/\/(.+)\.spec\.whatwg\.org\/?/);
     if (whatwg) {
-        return whatwg[1];
+      return whatwg[1];
     }
 
     // Handle TC39 Proposals
-    const tc39 = url.match(/\/\/tc39\.es\/proposal-([^\/]+)\/$/);
+    const tc39 = url.match(/\/\/tc39\.es\/proposal-([^/]+)\/$/);
     if (tc39) {
-        return "tc39-" + tc39[1];
+      return 'tc39-' + tc39[1];
     }
 
-
     // Handle Khronos extensions
-    const khronos = url.match(/https:\/\/registry\.khronos\.org\/webgl\/extensions\/([^\/]+)\/$/);
+    const khronos = url.match(/https:\/\/registry\.khronos\.org\/webgl\/extensions\/([^/]+)\/$/);
     if (khronos) {
-        return khronos[1];
+      return khronos[1];
     }
 
     // Handle extension specs defined in the same repo as the main spec
     // (e.g. generate a "gamepad-extensions" name for
     // https://w3c.github.io/gamepad/extensions.html")
-    const ext = url.match(/\/.*\.github\.io\/([^\/]+)\/(extensions?)\.html$/);
+    const ext = url.match(/\/.*\.github\.io\/([^/]+)\/(extensions?)\.html$/);
     if (ext) {
       return ext[1] + '-' + ext[2];
     }
 
     // Handle draft specs on GitHub, excluding the "webappsec-" prefix for
     // specifications developed by the Web Application Security Working Group
-    const github = url.match(/\/.*\.github\.io\/(?:webappsec-)?([^\/]+)\//);
+    const github = url.match(/\/.*\.github\.io\/(?:webappsec-)?([^/]+)\//);
     if (github) {
-        return github[1];
+      return github[1];
     }
 
     // Handle CSS WG specs
-    const css = url.match(/\/drafts\.(?:csswg|fxtf|css-houdini)\.org\/([^\/]+)\//);
+    const css = url.match(/\/drafts\.(?:csswg|fxtf|css-houdini)\.org\/([^/]+)\//);
     if (css) {
       return css[1];
     }
 
     // Handle SVG drafts
-    const svg = url.match(/\/svgwg\.org\/specs\/(?:svg-)?([^\/]+)\//);
+    const svg = url.match(/\/svgwg\.org\/specs\/(?:svg-)?([^/]+)\//);
     if (svg) {
-      return "svg-" + svg[1];
+      return 'svg-' + svg[1];
     }
 
     // Return name when one was given
@@ -98,7 +96,7 @@ function computeShortname(url) {
       return url;
     }
 
-    throw `Cannot extract meaningful name from ${url}`;
+    throw new Error(`Cannot extract meaningful name from ${url}`);
   }
 
   // Parse the URL to extract the name
@@ -108,139 +106,138 @@ function computeShortname(url) {
   // Latin characters (a-z letters, digits, underscore and "-"), and that it
   // only contains a dot for fractional levels at the end of the name
   // (e.g. "blah-1.2" is good but "blah.blah" and "blah-3.1-blah" are not)
-  if (!name.match(/^[\w\-]+((?<=\-\d+)\.\d+)?$/)) {
-    throw `Specification name contains unexpected characters: ${name} (extracted from ${url})`;
+  if (!name.match(/^[\w-]+((?<=-\d+)\.\d+)?$/)) {
+    throw new Error(`Specification name contains unexpected characters: ${name} (extracted from ${url})`);
   }
 
   return name;
 }
 
-
 // shortnames for specs that should no longer be linked to
 const shortNamesOfTransferedSpecs = {
-  "2dcontext": "html",
-  "2dcontext2": "html",
-  "cors":  "fetch",
-  "custom-elements": "html",
-  "domcore": "dom",
-  "eventsource": "html",
-  "html5": "html",
-  "html50": "html",
-  "html51": "html",
-  "html52": "html",
-  "selectors-api": "dom",
-  "webmessaging": "html",
-  "websockets": "html",
-  "html": "html",
-  "webstorage": "html",
-  "workers": "html",
-  "worklets-1": "html",
-  "WebIDL": "webidl",
-  "WebIDL-1": "webidl"
+  '2dcontext': 'html',
+  '2dcontext2': 'html',
+  cors: 'fetch',
+  'custom-elements': 'html',
+  domcore: 'dom',
+  eventsource: 'html',
+  html5: 'html',
+  html50: 'html',
+  html51: 'html',
+  html52: 'html',
+  'selectors-api': 'dom',
+  webmessaging: 'html',
+  websockets: 'html',
+  html: 'html',
+  webstorage: 'html',
+  workers: 'html',
+  'worklets-1': 'html',
+  WebIDL: 'webidl',
+  'WebIDL-1': 'webidl'
 };
 
 const outdatedShortnames = {
-  "BackgroundSync": "background-sync",
-  "content-security-policy": "CSP",
-  "css-selectors": "selectors",
-  "css-selectors-3": "selectors-3",
-  "css3-align": "css-align-3",
-  "css3-animations": "css-animations-1",
-  "css3-background": "css-backgrounds",
-  "css3-box": "css-box-3",
-  "css3-break": "css-break-3",
-  "css3-color": "css-color-3",
-  "css3-flexbox": "css-flexbox-1",
-  "css3-fonts": "css-fonts-3",
-  "css3-grid-layout": "css-grid-1",
-  "css3-images": "css-images-3",
-  "css3-mediaqueries": "mediaqueries-3",
-  "css3-multicol": "css-multicol-1",
-  "css3-namespace": "css-namespaces-3",
-  "css3-page": "css-page-3",
-  "css3-positioning": "css-position",
-  "css3-regions": "css-regions-1",
-  "css3-selectors": "selectors-3",
-  "css3-speech": "css-speech-1",
-  "css3-syntax": "css-syntax-3",
-  "css3-text": "css-text-3",
-  "css3-transforms": "css-transforms-1",
-  "css3-transitions": "css-transitions-1",
-  "css3-values": "css-values-3",
-  "css3-writing-modes": "css-writing-modes-3",
-  "feature-policy": "permissions-policy",
-  "InputDeviceCapabilities": "input-device-capabilities",
-  "IntersectionObserver": "intersection-observer",
-  "mixedcontent": "mixed-content",
-  "ServiceWorker": "service-workers",
-  "powerfulfeatures": "secure-contexts",
+  BackgroundSync: 'background-sync',
+  'content-security-policy': 'CSP',
+  'css-selectors': 'selectors',
+  'css-selectors-3': 'selectors-3',
+  'css3-align': 'css-align-3',
+  'css3-animations': 'css-animations-1',
+  'css3-background': 'css-backgrounds',
+  'css3-box': 'css-box-3',
+  'css3-break': 'css-break-3',
+  'css3-color': 'css-color-3',
+  'css3-flexbox': 'css-flexbox-1',
+  'css3-fonts': 'css-fonts-3',
+  'css3-grid-layout': 'css-grid-1',
+  'css3-images': 'css-images-3',
+  'css3-mediaqueries': 'mediaqueries-3',
+  'css3-multicol': 'css-multicol-1',
+  'css3-namespace': 'css-namespaces-3',
+  'css3-page': 'css-page-3',
+  'css3-positioning': 'css-position',
+  'css3-regions': 'css-regions-1',
+  'css3-selectors': 'selectors-3',
+  'css3-speech': 'css-speech-1',
+  'css3-syntax': 'css-syntax-3',
+  'css3-text': 'css-text-3',
+  'css3-transforms': 'css-transforms-1',
+  'css3-transitions': 'css-transitions-1',
+  'css3-values': 'css-values-3',
+  'css3-writing-modes': 'css-writing-modes-3',
+  'feature-policy': 'permissions-policy',
+  InputDeviceCapabilities: 'input-device-capabilities',
+  IntersectionObserver: 'intersection-observer',
+  mixedcontent: 'mixed-content',
+  ServiceWorker: 'service-workers',
+  powerfulfeatures: 'secure-contexts'
 };
 
 // TODO: check the link is non-normative (somehow)
 const shortnameOfNonNormativeDocs = [
-  "accept-encoding-range-test",
-  "aria-practices",
-  "Audio-EQ-Cookbook",
-  "books",
-  "capability-urls",
-  "clreq",
-  "css-2017",
-  "css-print",
-  "css3-marquee",
-  "css3-preslev",
-  "design-principles",
-  "discovery-api",
-  "dpub-latinreq",
-  "dpub-pagination",
-  "file-system-api",
-  "fingerprinting-guidance",
-  "html-design-principles",
-  "ilreq",
-  "installable-webapps",
-  "jlreq",
-  "klreq",
-  "media-accessibility-reqs",
-  "media-source-testcoverage",
-  "motion-sensors",
-  "predefined-counter-styles",
-  "rdf11-primer",
-  "security-privacy-questionnaire",
-  "security-questionnaire",
-  "sensor-polyfills",
-  "sensors",
-  "sniffly",
-  "spatial-navigation",
-  "ssml-sayas",
-  "storage-partitioning",
-  "streamproc",
-  "touch-events-extensions",
-  "typography",
-  "using-aria",
-  "wai-aria-implementation",
-  "wai-aria-practices",
-  "wai-aria-practices-1.1",
-  "wai-aria-practices-1.2",
-  "wai-aria-roadmap",
-  "wake-lock-use-cases",
-  "web-audio-perf",
-  "web-intents",
-  "webaudio-usecases",
-  "webdatabase",
-  "webrtc-interop-reports",
-  "webrtc-nv-use-cases"
+  'accept-encoding-range-test',
+  'aria-practices',
+  'Audio-EQ-Cookbook',
+  'books',
+  'capability-urls',
+  'clreq',
+  'css-2017',
+  'css-print',
+  'css3-marquee',
+  'css3-preslev',
+  'design-principles',
+  'discovery-api',
+  'dpub-latinreq',
+  'dpub-pagination',
+  'file-system-api',
+  'fingerprinting-guidance',
+  'html-design-principles',
+  'ilreq',
+  'installable-webapps',
+  'jlreq',
+  'klreq',
+  'media-accessibility-reqs',
+  'media-source-testcoverage',
+  'motion-sensors',
+  'predefined-counter-styles',
+  'rdf11-primer',
+  'security-privacy-questionnaire',
+  'security-questionnaire',
+  'sensor-polyfills',
+  'sensors',
+  'sniffly',
+  'spatial-navigation',
+  'ssml-sayas',
+  'storage-partitioning',
+  'streamproc',
+  'touch-events-extensions',
+  'typography',
+  'using-aria',
+  'wai-aria-implementation',
+  'wai-aria-practices',
+  'wai-aria-practices-1.1',
+  'wai-aria-practices-1.2',
+  'wai-aria-roadmap',
+  'wake-lock-use-cases',
+  'web-audio-perf',
+  'web-intents',
+  'webaudio-usecases',
+  'webdatabase',
+  'webrtc-interop-reports',
+  'webrtc-nv-use-cases'
 ];
 
 // the fragment part of URLs aren't systematically URL-encoded
 // so we compare links both with and without an additional URL encoding pass
 const matchAnchor = (url, anchor) => link => {
-  return link === (url + "#" + anchor) || link === (url + "#" + encodeURIComponent(anchor));
+  return link === (url + '#' + anchor) || link === (url + '#' + encodeURIComponent(anchor));
 };
 
-function studyBackrefs(edResults, trResults = [], htmlFragments = {}) {
+function studyBackrefs (edResults, trResults = [], htmlFragments = {}) {
   trResults = trResults || [];
   const report = [];
 
-  const recordAnomaly = recordCategorizedAnomaly(report, "links", possibleAnomalies);
+  const recordAnomaly = recordCategorizedAnomaly(report, 'links', possibleAnomalies);
 
   edResults.forEach(spec => {
     Object.keys(spec.links || {})
@@ -251,7 +248,7 @@ function studyBackrefs(edResults, trResults = [], htmlFragments = {}) {
           shortname = spec.links[link].specShortname;
         } else {
           let nakedLink = link;
-          if (nakedLink.endsWith(".html")) {
+          if (nakedLink.endsWith('.html')) {
             nakedLink = nakedLink.replace(/\/(Overview|overview|index)\.html$/, '/');
           }
           if (nakedLink[nakedLink.length - 1] !== '/') {
@@ -263,8 +260,8 @@ function studyBackrefs(edResults, trResults = [], htmlFragments = {}) {
           if (match) {
             // ED should not link to dated versions of the spec, unless it
             // voluntarily links to previous versions of itself
-            if ((match[2] !== spec.shortname || outdatedShortnames[match[2]] === spec.shortname) && !["REC", "NOTE"].includes(match[1])) {
-              recordAnomaly(spec, "datedUrls", link);
+            if ((match[2] !== spec.shortname || outdatedShortnames[match[2]] === spec.shortname) && !['REC', 'NOTE'].includes(match[1])) {
+              recordAnomaly(spec, 'datedUrls', link);
             }
 
             // TODO: consider pursuing the analysis with the non-dated version,
@@ -279,42 +276,41 @@ function studyBackrefs(edResults, trResults = [], htmlFragments = {}) {
             r.url === nakedLink ||
               (r.release && r.release.url === nakedLink) ||
               r.nightly.url === nakedLink ||
-              (r.series && nakedLink === `https://www.w3.org/TR/${r.series.shortname}/`) ) || {}).shortname;
+              (r.series && nakedLink === `https://www.w3.org/TR/${r.series.shortname}/`)) || {}).shortname;
 
           // If it does not match any known URL, try to compute a shortname out of
           // it directly.
           if (!shortname) {
             try {
               shortname = computeShortname(nakedLink);
-            }
-            catch (e) {
-              recordAnomaly(spec, "unknownSpecs", link);
+            } catch (e) {
+              recordAnomaly(spec, 'unknownSpecs', link);
               return;
             }
           }
         }
 
-        if ((link.match(/w3\.org/) || link.match(/w3c\.github\.io/))  && shortNamesOfTransferedSpecs[shortname]) {
+        if ((link.match(/w3\.org/) || link.match(/w3c\.github\.io/)) && shortNamesOfTransferedSpecs[shortname]) {
           // The specification should no longer be referenced.
           // In theory, we could still try to match the anchor against the
           // right spec. In practice, these outdated specs are sufficiently
           // outdated that it does not make a lot of sense to do so.
-          recordAnomaly(spec, "outdatedSpecs", link);
+          recordAnomaly(spec, 'outdatedSpecs', link);
           return;
         }
         // Links to WHATWG commit snapshots
         if (link.match(/spec\.whatwg\.org/) && link.match(/commit-snapshots/)) {
-          recordAnomaly(spec, "outdatedSpecs", link);
+          recordAnomaly(spec, 'outdatedSpecs', link);
           return;
         }
 
         if (link.match(/heycam\.github\.io/)) {
-          recordAnomaly(spec, "nonCanonicalRefs", link);
-          shortname = "webidl";
+          recordAnomaly(spec, 'nonCanonicalRefs', link);
+          shortname = 'webidl';
         }
         if (outdatedShortnames[shortname]) {
           shortname = outdatedShortnames[shortname];
-          recordAnomaly(spec, "nonCanonicalRefs", link);
+          recordAnomaly(spec, 'nonCanonicalRefs', link);
         }
 
         // At this point, we managed to associate the link with a shortname,
@@ -326,13 +322,13 @@ function studyBackrefs(edResults, trResults = [], htmlFragments = {}) {
           edResults.find(s => s.series.shortname === shortname && s.series.currentSpecification === s.shortname);
         if (!sourceSpec) {
           if (!shortnameOfNonNormativeDocs.includes(shortname)) {
-            recordAnomaly(spec, "unknownSpecs", link);
+            recordAnomaly(spec, 'unknownSpecs', link);
           }
           return;
         }
         if (sourceSpec.error) {
           // no point in reporting an error on failed crawls
-          recordAnomaly(spec, "crawlError", link);
+          recordAnomaly(spec, 'crawlError', link);
           return;
         }
 
@@ -354,7 +350,7 @@ function studyBackrefs(edResults, trResults = [], htmlFragments = {}) {
 
         // Check anchors
         const anchors = spec.links[link].anchors || [];
-        for (let anchor of anchors) {
+        for (const anchor of anchors) {
           const baseLink = (sourceSpec.nightly.url === link || sourceSpec.nightly?.pages?.includes(link)) ? link : sourceSpec.nightly.url;
           const matchFullNightlyLink = matchAnchor(baseLink, anchor);
           const matchFullReleaseLink = matchAnchor((sourceSpec.release || sourceSpec.nightly).url, anchor);
@@ -363,34 +359,35 @@ function studyBackrefs(edResults, trResults = [], htmlFragments = {}) {
           const dfn = dfns.find(d => matchFullNightlyLink(d.href));
           if (!isKnownId) {
             if ((trSourceSpec.ids || []).find(matchFullReleaseLink) && link.match(/w3\.org\/TR\//)) {
-              recordAnomaly(spec, "evolvingLinks", link + "#" + anchor);
+              recordAnomaly(spec, 'evolvingLinks', link + '#' + anchor);
             } else {
-              if (link.startsWith("https://html.spec.whatwg.org/C") || link.startsWith("http://html.spec.whatwg.org/C")) {
-                recordAnomaly(spec, "nonCanonicalRefs", link);
-                link = link.replace("http:", "https:").replace("https://html.spec.whatwg.org/C", "https://html.spec.whatwg.org/multipage");
+              if (link.startsWith('https://html.spec.whatwg.org/C') || link.startsWith('http://html.spec.whatwg.org/C')) {
+                recordAnomaly(spec, 'nonCanonicalRefs', link);
+                link = link.replace('http:', 'https:').replace('https://html.spec.whatwg.org/C', 'https://html.spec.whatwg.org/multipage');
               }
               // Links to single-page version of HTML spec
-              if (link === "https://html.spec.whatwg.org/"
+              if (link === 'https://html.spec.whatwg.org/' &&
                   // is there an equivalent id in the multipage spec?
-                  && ids.find(i => i.startsWith("https://html.spec.whatwg.org/multipage/") && i.endsWith("#" + anchor) || i.endsWith("#" + encodeURIComponent(anchor)))) {
-                    // Should we keep track of those? ignoring for now
-              } else if (link.startsWith("https://html.spec.whatwg.org/multipage") && htmlFragments
-                         && htmlFragments[anchor]
-                         && ids.find(matchAnchor(`https://html.spec.whatwg.org/multipage/${htmlFragments[anchor]}.html`,anchor))) {
+                  ids.find(i => i.startsWith('https://html.spec.whatwg.org/multipage/') &&
+                    (i.endsWith('#' + anchor) || i.endsWith('#' + encodeURIComponent(anchor))))) {
+                // Should we keep track of those? ignoring for now
+              } else if (link.startsWith('https://html.spec.whatwg.org/multipage') && htmlFragments &&
+                         htmlFragments[anchor] &&
+                         ids.find(matchAnchor(`https://html.spec.whatwg.org/multipage/${htmlFragments[anchor]}.html`, anchor))) {
                 // Deal with anchors that are JS-redirected from
                 // the multipage version of HTML
-                recordAnomaly(spec, "frailLinks", link + "#" + anchor);
+                recordAnomaly(spec, 'frailLinks', link + '#' + anchor);
               } else if (anchor.startsWith(':~:text=')) {
                 // links using text fragments are inherently fragile
-                recordAnomaly(spec, "frailLinks", link + "#" + anchor);
+                recordAnomaly(spec, 'frailLinks', link + '#' + anchor);
               } else {
-                recordAnomaly(spec, "brokenLinks", link + "#" + anchor);
+                recordAnomaly(spec, 'brokenLinks', link + '#' + anchor);
               }
             }
           } else if (!heading && !dfn) {
-            recordAnomaly(spec, "notDfn", link + "#" + anchor);
-          } else if (dfn && dfn.access !== "public") {
-            recordAnomaly(spec, "notExported", link  + "#" + anchor);
+            recordAnomaly(spec, 'notDfn', link + '#' + anchor);
+          } else if (dfn && dfn.access !== 'public') {
+            recordAnomaly(spec, 'notExported', link + '#' + anchor);
           }
         }
       });

--- a/src/lib/study-webidl.js
+++ b/src/lib/study-webidl.js
@@ -3,7 +3,7 @@
  *
  * Returned report is a list of anomalies. Each anomaly follows the following
  * object structure:
- * 
+ *
  * {
  *   "category": "webidl",
  *   "name": "type of anomaly",
@@ -24,124 +24,123 @@
  * the crawl results parameter.
  */
 
-const { recordCategorizedAnomaly } = require("./util");
-const WebIDL2 = require("webidl2");
+const { recordCategorizedAnomaly } = require('./util');
+const WebIDL2 = require('webidl2');
 
-const getSpecs = list => [...new Set(list.map(({spec}) => spec))];
+const getSpecs = list => [...new Set(list.map(({ spec }) => spec))];
 const specName = spec => spec.shortname ?? spec.url;
 const dfnName = dfn => `${dfn.idl.partial ? 'partial ' : ''}${dfn.idl.type} "${dfn.idl.name}"`;
 
 const possibleAnomalies = [
-  "incompatiblePartialIdlExposure",
-  "invalid",
-  "noExposure",
-  "noOriginalDefinition",
-  "overloaded",
-  "redefined",
-  "redefinedIncludes",
-  "redefinedMember",
-  "redefinedWithDifferentTypes",
-  "singleEnumValue",
-  "unexpectedEventHandler",
-  "unknownExposure",
-  "unknownExtAttr",
-  "unknownType",
-  "wrongCaseEnumValue",
-  "wrongKind",
-  "wrongType"
+  'incompatiblePartialIdlExposure',
+  'invalid',
+  'noExposure',
+  'noOriginalDefinition',
+  'overloaded',
+  'redefined',
+  'redefinedIncludes',
+  'redefinedMember',
+  'redefinedWithDifferentTypes',
+  'singleEnumValue',
+  'unexpectedEventHandler',
+  'unknownExposure',
+  'unknownExtAttr',
+  'unknownType',
+  'wrongCaseEnumValue',
+  'wrongKind',
+  'wrongType'
 ];
 
 const basicTypes = new Set([
   // Types defined by Web IDL itself:
-  "any", // https://webidl.spec.whatwg.org/#idl-any
-  "ArrayBuffer", // https://webidl.spec.whatwg.org/#idl-ArrayBuffer
-  "bigint", // https://webidl.spec.whatwg.org/#idl-bigint
-  "boolean", // https://webidl.spec.whatwg.org/#idl-boolean
-  "byte", // https://webidl.spec.whatwg.org/#idl-byte
-  "ByteString", // https://webidl.spec.whatwg.org/#idl-ByteString
-  "DataView", // https://webidl.spec.whatwg.org/#idl-DataView
-  "DOMString", // https://webidl.spec.whatwg.org/#idl-DOMString
-  "double", // https://webidl.spec.whatwg.org/#idl-double
-  "float", // https://webidl.spec.whatwg.org/#idl-float
-  "Float32Array", // https://webidl.spec.whatwg.org/#idl-Float32Array
-  "Float64Array", // https://webidl.spec.whatwg.org/#idl-Float64Array
-  "Int16Array", // https://webidl.spec.whatwg.org/#idl-Int16Array
-  "Int32Array", // https://webidl.spec.whatwg.org/#idl-Int32Array
-  "Int8Array", // https://webidl.spec.whatwg.org/#idl-Int8Array
-  "long long", // https://webidl.spec.whatwg.org/#idl-long-long
-  "long", // https://webidl.spec.whatwg.org/#idl-long
-  "object", // https://webidl.spec.whatwg.org/#idl-object
-  "octet", // https://webidl.spec.whatwg.org/#idl-octet
-  "short", // https://webidl.spec.whatwg.org/#idl-short
-  "symbol", // https://webidl.spec.whatwg.org/#idl-symbol
-  "BigUint64Array", // https://webidl.spec.whatwg.org/#idl-BigUint64Array
-  "BigInt64Array", // https://webidl.spec.whatwg.org/#idl-BigInt64Array
-  "Uint16Array", // https://webidl.spec.whatwg.org/#idl-Uint16Array
-  "Uint32Array", // https://webidl.spec.whatwg.org/#idl-Uint32Array
-  "Uint8Array", // https://webidl.spec.whatwg.org/#idl-Uint8Array
-  "Uint8ClampedArray", // https://webidl.spec.whatwg.org/#idl-Uint8ClampedArray
-  "unrestricted double", // https://webidl.spec.whatwg.org/#idl-unrestricted-double
-  "unrestricted float", // https://webidl.spec.whatwg.org/#idl-unrestricted-float
-  "unsigned long long", // https://webidl.spec.whatwg.org/#idl-unsigned-long-long
-  "unsigned long", // https://webidl.spec.whatwg.org/#idl-unsigned-long
-  "unsigned short", // https://webidl.spec.whatwg.org/#idl-unsigned-short
-  "USVString", // https://webidl.spec.whatwg.org/#idl-USVString
-  "undefined", // https://webidl.spec.whatwg.org/#idl-undefined
+  'any', // https://webidl.spec.whatwg.org/#idl-any
+  'ArrayBuffer', // https://webidl.spec.whatwg.org/#idl-ArrayBuffer
+  'bigint', // https://webidl.spec.whatwg.org/#idl-bigint
+  'boolean', // https://webidl.spec.whatwg.org/#idl-boolean
+  'byte', // https://webidl.spec.whatwg.org/#idl-byte
+  'ByteString', // https://webidl.spec.whatwg.org/#idl-ByteString
+  'DataView', // https://webidl.spec.whatwg.org/#idl-DataView
+  'DOMString', // https://webidl.spec.whatwg.org/#idl-DOMString
+  'double', // https://webidl.spec.whatwg.org/#idl-double
+  'float', // https://webidl.spec.whatwg.org/#idl-float
+  'Float32Array', // https://webidl.spec.whatwg.org/#idl-Float32Array
+  'Float64Array', // https://webidl.spec.whatwg.org/#idl-Float64Array
+  'Int16Array', // https://webidl.spec.whatwg.org/#idl-Int16Array
+  'Int32Array', // https://webidl.spec.whatwg.org/#idl-Int32Array
+  'Int8Array', // https://webidl.spec.whatwg.org/#idl-Int8Array
+  'long long', // https://webidl.spec.whatwg.org/#idl-long-long
+  'long', // https://webidl.spec.whatwg.org/#idl-long
+  'object', // https://webidl.spec.whatwg.org/#idl-object
+  'octet', // https://webidl.spec.whatwg.org/#idl-octet
+  'short', // https://webidl.spec.whatwg.org/#idl-short
+  'symbol', // https://webidl.spec.whatwg.org/#idl-symbol
+  'BigUint64Array', // https://webidl.spec.whatwg.org/#idl-BigUint64Array
+  'BigInt64Array', // https://webidl.spec.whatwg.org/#idl-BigInt64Array
+  'Uint16Array', // https://webidl.spec.whatwg.org/#idl-Uint16Array
+  'Uint32Array', // https://webidl.spec.whatwg.org/#idl-Uint32Array
+  'Uint8Array', // https://webidl.spec.whatwg.org/#idl-Uint8Array
+  'Uint8ClampedArray', // https://webidl.spec.whatwg.org/#idl-Uint8ClampedArray
+  'unrestricted double', // https://webidl.spec.whatwg.org/#idl-unrestricted-double
+  'unrestricted float', // https://webidl.spec.whatwg.org/#idl-unrestricted-float
+  'unsigned long long', // https://webidl.spec.whatwg.org/#idl-unsigned-long-long
+  'unsigned long', // https://webidl.spec.whatwg.org/#idl-unsigned-long
+  'unsigned short', // https://webidl.spec.whatwg.org/#idl-unsigned-short
+  'USVString', // https://webidl.spec.whatwg.org/#idl-USVString
+  'undefined', // https://webidl.spec.whatwg.org/#idl-undefined
 
   // Types defined by other specs:
-  "CSSOMString", // https://drafts.csswg.org/cssom/#cssomstring-type
-  "WindowProxy" // https://html.spec.whatwg.org/multipage/window-object.html#windowproxy
+  'CSSOMString', // https://drafts.csswg.org/cssom/#cssomstring-type
+  'WindowProxy' // https://html.spec.whatwg.org/multipage/window-object.html#windowproxy
 ]);
-
 
 const knownExtAttrs = new Set([
   // Extended attributes defined by Web IDL itself:
-  "AllowResizable", // https://webidl.spec.whatwg.org/#AllowResizable
-  "AllowShared", // https://webidl.spec.whatwg.org/#AllowShared
-  "Clamp", // https://webidl.spec.whatwg.org/#Clamp
-  "CrossOriginIsolated", // https://webidl.spec.whatwg.org/#CrossOriginIsolated
-  "Default", // https://webidl.spec.whatwg.org/#Default
-  "EnforceRange", // https://webidl.spec.whatwg.org/#EnforceRange
-  "Exposed", // https://webidl.spec.whatwg.org/#Exposed
-  "Global", // https://webidl.spec.whatwg.org/#Global
-  "LegacyFactoryFunction", // https://webidl.spec.whatwg.org/#LegacyFactoryFunction
-  "LegacyLenientSetter", // https://webidl.spec.whatwg.org/#LegacyLenientSetter
-  "LegacyLenientThis", // https://webidl.spec.whatwg.org/#LegacyLenientThis
-  "LegacyNamespace", // https://webidl.spec.whatwg.org/#LegacyNamespace
-  "LegacyNoInterfaceObject", // https://webidl.spec.whatwg.org/#LegacyNoInterfaceObject
-  "LegacyNullToEmptyString", // https://webidl.spec.whatwg.org/#LegacyNullToEmptyString
-  "LegacyOverrideBuiltIns", // https://webidl.spec.whatwg.org/#LegacyOverrideBuiltIns
-  "LegacyTreatNonObjectAsNull", // https://webidl.spec.whatwg.org/#LegacyTreatNonObjectAsNull
-  "LegacyUnenumerableNamedProperties", // https://webidl.spec.whatwg.org/#LegacyUnenumerableNamedProperties
-  "LegacyUnforgeable", // https://webidl.spec.whatwg.org/#LegacyUnforgeable
-  "LegacyWindowAlias", // https://webidl.spec.whatwg.org/#LegacyWindowAlias
-  "NewObject", // https://webidl.spec.whatwg.org/#NewObject
-  "PutForwards", // https://webidl.spec.whatwg.org/#PutForwards
-  "Replaceable", // https://webidl.spec.whatwg.org/#Replaceable
-  "SameObject", // https://webidl.spec.whatwg.org/#SameObject
-  "SecureContext", // https://webidl.spec.whatwg.org/#SecureContext
-  "Unscopable", // https://webidl.spec.whatwg.org/#Unscopable
+  'AllowResizable', // https://webidl.spec.whatwg.org/#AllowResizable
+  'AllowShared', // https://webidl.spec.whatwg.org/#AllowShared
+  'Clamp', // https://webidl.spec.whatwg.org/#Clamp
+  'CrossOriginIsolated', // https://webidl.spec.whatwg.org/#CrossOriginIsolated
+  'Default', // https://webidl.spec.whatwg.org/#Default
+  'EnforceRange', // https://webidl.spec.whatwg.org/#EnforceRange
+  'Exposed', // https://webidl.spec.whatwg.org/#Exposed
+  'Global', // https://webidl.spec.whatwg.org/#Global
+  'LegacyFactoryFunction', // https://webidl.spec.whatwg.org/#LegacyFactoryFunction
+  'LegacyLenientSetter', // https://webidl.spec.whatwg.org/#LegacyLenientSetter
+  'LegacyLenientThis', // https://webidl.spec.whatwg.org/#LegacyLenientThis
+  'LegacyNamespace', // https://webidl.spec.whatwg.org/#LegacyNamespace
+  'LegacyNoInterfaceObject', // https://webidl.spec.whatwg.org/#LegacyNoInterfaceObject
+  'LegacyNullToEmptyString', // https://webidl.spec.whatwg.org/#LegacyNullToEmptyString
+  'LegacyOverrideBuiltIns', // https://webidl.spec.whatwg.org/#LegacyOverrideBuiltIns
+  'LegacyTreatNonObjectAsNull', // https://webidl.spec.whatwg.org/#LegacyTreatNonObjectAsNull
+  'LegacyUnenumerableNamedProperties', // https://webidl.spec.whatwg.org/#LegacyUnenumerableNamedProperties
+  'LegacyUnforgeable', // https://webidl.spec.whatwg.org/#LegacyUnforgeable
+  'LegacyWindowAlias', // https://webidl.spec.whatwg.org/#LegacyWindowAlias
+  'NewObject', // https://webidl.spec.whatwg.org/#NewObject
+  'PutForwards', // https://webidl.spec.whatwg.org/#PutForwards
+  'Replaceable', // https://webidl.spec.whatwg.org/#Replaceable
+  'SameObject', // https://webidl.spec.whatwg.org/#SameObject
+  'SecureContext', // https://webidl.spec.whatwg.org/#SecureContext
+  'Unscopable', // https://webidl.spec.whatwg.org/#Unscopable
 
   // Extended attributes defined by other specs:
-  "CEReactions", // https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions
-  "HTMLConstructor", // https://html.spec.whatwg.org/multipage/dom.html#htmlconstructor
-  "Serializable", // https://html.spec.whatwg.org/multipage/structured-data.html#serializable
-  "StringContext", // https://w3c.github.io/webappsec-trusted-types/dist/spec/#webidl-string-context-xattr
-  "Transferable", // https://html.spec.whatwg.org/multipage/structured-data.html#transferable
-  "WebGLHandlesContextLoss" // https://registry.khronos.org/webgl/specs/latest/1.0/##5.14
+  'CEReactions', // https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions
+  'HTMLConstructor', // https://html.spec.whatwg.org/multipage/dom.html#htmlconstructor
+  'Serializable', // https://html.spec.whatwg.org/multipage/structured-data.html#serializable
+  'StringContext', // https://w3c.github.io/webappsec-trusted-types/dist/spec/#webidl-string-context-xattr
+  'Transferable', // https://html.spec.whatwg.org/multipage/structured-data.html#transferable
+  'WebGLHandlesContextLoss' // https://registry.khronos.org/webgl/specs/latest/1.0/##5.14
 ]);
 
 const listIdlTypes = type => {
   if (Array.isArray(type)) return type.map(listIdlTypes).flat();
-  if (typeof type === "string") return [type];
+  if (typeof type === 'string') return [type];
   return listIdlTypes(type.idlType);
 };
 
 // Helper to test if two members define the same thing, such as the same
 // attribute or the same method. Should match requirements in spec:
 // https://heycam.github.io/webidl/#idl-overloading
-function isOverloadedOperation(a, b) {
-  if (a.type !== "constructor" && a.type !== "operation") {
+function isOverloadedOperation (a, b) {
+  if (a.type !== 'constructor' && a.type !== 'operation') {
     return false;
   }
   if (a.type !== b.type) {
@@ -161,8 +160,8 @@ function isOverloadedOperation(a, b) {
 // Helper to test if two members define an operation with the same identifier,
 // one of them being a static operation and the other a regular one. This is
 // allowed in Web IDL, see https://github.com/whatwg/webidl/issues/1097
-function isAllowedOperationWithSameIdentifier(a, b) {
-  if (a.type !== "operation") {
+function isAllowedOperationWithSameIdentifier (a, b) {
+  if (a.type !== 'operation') {
     return false;
   }
   if (a.type !== b.type) {
@@ -171,7 +170,7 @@ function isAllowedOperationWithSameIdentifier(a, b) {
   if (a.name !== b.name) {
     return false;
   }
-  if (a.special !== "static" && b.special !== "static") {
+  if (a.special !== 'static' && b.special !== 'static') {
     return false;
   }
   if (a.special === b.special) {
@@ -180,64 +179,61 @@ function isAllowedOperationWithSameIdentifier(a, b) {
   return true;
 }
 
-function describeMember(member) {
+function describeMember (member) {
   let desc = member.type;
   if (member.name) {
-    desc += " " + member.name;
+    desc += ' ' + member.name;
   }
   if (member.special) {
-    desc = member.special + " " + desc;
+    desc = member.special + ' ' + desc;
   }
   return desc;
 }
 
-
-function studyWebIdl(edResults, curatedResults) {
-  const report = [];              // List of anomalies to report
-  const dfns = {};                // Index of IDL definitions (save includes)
-  const includesStatements = {};  // Index of "includes" statements
-  const globals = {};             // Index of globals defined in the IDL
-  const objectTypes = {};         // Index of interface types
-  const usedTypes = {};           // Index of types used in the IDL
-  const usedExtAttrs = {};        // Index of extended attributes
+function studyWebIdl (edResults, curatedResults) {
+  const report = []; // List of anomalies to report
+  const dfns = {}; // Index of IDL definitions (save includes)
+  const includesStatements = {}; // Index of "includes" statements
+  const globals = {}; // Index of globals defined in the IDL
+  const usedTypes = {}; // Index of types used in the IDL
+  const usedExtAttrs = {}; // Index of extended attributes
 
   // Record an anomaly for the given spec(s).
-  const recordAnomaly = recordCategorizedAnomaly(report, "webidl", possibleAnomalies);
+  const recordAnomaly = recordCategorizedAnomaly(report, 'webidl', possibleAnomalies);
 
-  function inheritsFrom(iface, ancestor) {
+  function inheritsFrom (iface, ancestor) {
     if (!iface.inheritance) return false;
     if (iface.inheritance === ancestor) return true;
-    const parentInterface = dfns[iface.inheritance].find(({idl}) => !idl.partial)?.idl;
+    const parentInterface = dfns[iface.inheritance].find(({ idl }) => !idl.partial)?.idl;
     if (!parentInterface) return false;
     return inheritsFrom(parentInterface, ancestor);
   }
 
   // TODO: a full check of event handlers would require:
   // - checking if the interface doesn't include a mixin with eventhandlers
-  function checkEventHandlers(spec, memberHolder, iface = memberHolder) {
-    const eventHandler = memberHolder.members.find(m => m?.name?.startsWith("on") && m.type === "attribute" && m.idlType?.idlType === "EventHandler");
-    if (eventHandler && !inheritsFrom(iface, "EventTarget")) {
-      recordAnomaly(spec, "unexpectedEventHandler", `The interface "${iface.name}" defines an event handler "${eventHandler.name}" but does not inherit from EventTarget`);
+  function checkEventHandlers (spec, memberHolder, iface = memberHolder) {
+    const eventHandler = memberHolder.members.find(m => m?.name?.startsWith('on') && m.type === 'attribute' && m.idlType?.idlType === 'EventHandler');
+    if (eventHandler && !inheritsFrom(iface, 'EventTarget')) {
+      recordAnomaly(spec, 'unexpectedEventHandler', `The interface "${iface.name}" defines an event handler "${eventHandler.name}" but does not inherit from EventTarget`);
     }
   }
 
-  function getExposure(iface) {
-    let exposure = iface.extAttrs.find(ea => ea.name === "Exposed")?.rhs;
+  function getExposure (iface) {
+    let exposure = iface.extAttrs.find(ea => ea.name === 'Exposed')?.rhs;
     if (!exposure) {
       return [];
     }
-    if (exposure.type === "*") {
-      return ["*"];
+    if (exposure.type === '*') {
+      return ['*'];
     }
-    if (exposure.type === "identifier-list") {
-      exposure = exposure.value.map(({value}) => value);
-    }
-    else if (exposure.type === "identifier") {
+    if (exposure.type === 'identifier-list') {
+      exposure = exposure.value.map(({ value }) => value);
+    } else if (exposure.type === 'identifier') {
       exposure = [exposure.value];
     }
     // Expand encompassing globals to facilitate comparison
     let additionalExposures = [];
-    for (let value of exposure) {
+    for (const value of exposure) {
       if (globals[value]?.subrealms.length) {
         additionalExposures = additionalExposures.concat(globals[value].subrealms);
       }
@@ -247,57 +243,54 @@ function studyWebIdl(edResults, curatedResults) {
     return exposure;
   }
 
-  function checkExposure(spec, iface, mainInterface) {
+  function checkExposure (spec, iface, mainInterface) {
     // Make sure that the interface is defined somewhere
     const ifaceExposure = getExposure(iface);
     if (ifaceExposure.length === 0 && !iface.partial) {
-      recordAnomaly(spec, "noExposure", `The interface "${iface.name}" has no [Exposed] extended attribute`);
-    }
-    // Make sure that the interface is exposed on known globals
-    else if (ifaceExposure.length > 0 && ifaceExposure[0] !== "*") {
+      recordAnomaly(spec, 'noExposure', `The interface "${iface.name}" has no [Exposed] extended attribute`);
+    } else if (ifaceExposure.length > 0 && ifaceExposure[0] !== '*') {
+      // Make sure that the interface is exposed on known globals
       const unknown = ifaceExposure.filter(e => !Object.keys(globals).includes(e));
       if (unknown.length > 0) {
-        recordAnomaly(spec, "unknownExposure", `The [Exposed] extended attribute of the interface "${iface.name}" references unknown global(s): ${unknown.join(", ")}`);
+        recordAnomaly(spec, 'unknownExposure', `The [Exposed] extended attribute of the interface "${iface.name}" references unknown global(s): ${unknown.join(', ')}`);
       }
     }
 
     // Make sure that exposure of partial is compatible with original
     if (iface.partial) {
       const mainExposure = getExposure(mainInterface);
-      if (ifaceExposure[0] === "*" && mainExposure[0] !== "*") {
-        recordAnomaly(spec, "incompatiblePartialIdlExposure", `The partial interface "${iface.name}" is exposed on all globals but the original interface is not (${mainExposure.join(", ")})`);
-      }
-      else if (ifaceExposure.length > 0 && mainExposure.length > 0 && mainExposure[0] !== "*") {
+      if (ifaceExposure[0] === '*' && mainExposure[0] !== '*') {
+        recordAnomaly(spec, 'incompatiblePartialIdlExposure', `The partial interface "${iface.name}" is exposed on all globals but the original interface is not (${mainExposure.join(', ')})`);
+      } else if (ifaceExposure.length > 0 && mainExposure.length > 0 && mainExposure[0] !== '*') {
         const problematic = ifaceExposure.filter(x => !mainExposure.includes(x));
         if (problematic.length > 0) {
-          recordAnomaly(spec, "incompatiblePartialIdlExposure", `The [Exposed] extended attribute of the partial interface "${iface.name}" references globals on which the original interface is not exposed: ${problematic.join(", ")} (original exposure: ${mainExposure.join(", ")})`);
+          recordAnomaly(spec, 'incompatiblePartialIdlExposure', `The [Exposed] extended attribute of the partial interface "${iface.name}" references globals on which the original interface is not exposed: ${problematic.join(', ')} (original exposure: ${mainExposure.join(', ')})`);
         }
       }
     }
   }
 
-  function checkEnumMultipleValues(spec, idl) {
+  function checkEnumMultipleValues (spec, idl) {
     if (idl.values.length <= 1) {
-      recordAnomaly(spec, "singleEnumValue", `The enum "${idl.name}" has fewer than 2 possible values`);
+      recordAnomaly(spec, 'singleEnumValue', `The enum "${idl.name}" has fewer than 2 possible values`);
     }
   }
 
-  function checkSyntaxOfEnumValue(spec, idl) {
-    idl.values.forEach(({value}) => {
+  function checkSyntaxOfEnumValue (spec, idl) {
+    idl.values.forEach(({ value }) => {
       if (value.match(/[A-Z_]/)) {
-        recordAnomaly(spec, "wrongCaseEnumValue", `The value "${value}" of the enum "${idl.name}" does not match the expected conventions (lower case, hyphen separated words)`);
+        recordAnomaly(spec, 'wrongCaseEnumValue', `The value "${value}" of the enum "${idl.name}" does not match the expected conventions (lower case, hyphen separated words)`);
       }
     });
   }
 
-  function checkInheritance(spec, idl) {
+  function checkInheritance (spec, idl) {
     if (!idl.inheritance) return;
     const parent = dfns[idl.inheritance];
     if (!parent) {
-      recordAnomaly(spec, "unknownType", `"${idl.name}" inherits from "${idl.inheritance}" which is not defined anywhere`);
-    }
-    else if (parent[0].idl.type !== idl.type) {
-      recordAnomaly(spec, "wrongKind", `"${idl.name}" is of kind "${idl.type}" but inherits from "${idl.inheritance}" which is of kind "${parent[0].idl.type}"`);
+      recordAnomaly(spec, 'unknownType', `"${idl.name}" inherits from "${idl.inheritance}" which is not defined anywhere`);
+    } else if (parent[0].idl.type !== idl.type) {
+      recordAnomaly(spec, 'wrongKind', `"${idl.name}" is of kind "${idl.type}" but inherits from "${idl.inheritance}" which is of kind "${parent[0].idl.type}"`);
     }
   }
 
@@ -305,34 +298,32 @@ function studyWebIdl(edResults, curatedResults) {
   // that the node uses. Note that, in the indexes, we only store the root
   // definition, not the exact method or parameter where the type or extended
   // attribute is found.
-  function parseIdlNode(node, spec, dfn) {
+  function parseIdlNode (node, spec, dfn) {
     dfn = dfn ?? node;
     for (const [key, value] of Object.entries(node)) {
-      if (key === "idlType") {
+      if (key === 'idlType') {
         const idlTypes = listIdlTypes(value);
         for (const idlType of idlTypes) {
-                if (!usedTypes[idlType]) {
-                  usedTypes[idlType] = [];
-                }
-                usedTypes[idlType].push({ spec, idl: dfn });
+          if (!usedTypes[idlType]) {
+            usedTypes[idlType] = [];
+          }
+          usedTypes[idlType].push({ spec, idl: dfn });
         }
-      }
-      else if (key === "extAttrs" && Array.isArray(value)) {
+      } else if (key === 'extAttrs' && Array.isArray(value)) {
         for (const extAttr of value) {
           if (!usedExtAttrs[extAttr.name]) {
             usedExtAttrs[extAttr.name] = [];
           }
           usedExtAttrs[extAttr.name].push({ spec, idl: dfn });
         }
-      }
-      else if (typeof value === "object" && value !== null) {
+      } else if (typeof value === 'object' && value !== null) {
         // Recurse into methods and parameters
         parseIdlNode(value, spec, dfn);
       }
     }
   }
 
-  function checkMembers(target, source) {
+  function checkMembers (target, source) {
     source = source ?? target;
     const selfCheck = source === target;
     const knownDuplicates = [];
@@ -380,7 +371,7 @@ function studyWebIdl(edResults, curatedResults) {
 
         if (isOverloadedOperation(targetMember, sourceMember)) {
           if (!selfCheck) {
-            recordAnomaly(specs, "overloaded", `"${describeMember(targetMember)}" in ${targetName} overloads an operation defined in ${sourceName}`);
+            recordAnomaly(specs, 'overloaded', `"${describeMember(targetMember)}" in ${targetName} overloads an operation defined in ${sourceName}`);
           }
           break;
         }
@@ -392,10 +383,9 @@ function studyWebIdl(edResults, curatedResults) {
 
         if (!knownDuplicates.includes(targetMember.name)) {
           if (selfCheck) {
-            recordAnomaly(specs, "redefinedMember", `"${targetMember.name}" in ${targetName} is defined more than once`);
-          }
-          else {
-            recordAnomaly(specs, "redefinedMember", `"${targetMember.name}" in ${targetName} duplicates a member defined in ${sourceName}`);
+            recordAnomaly(specs, 'redefinedMember', `"${targetMember.name}" in ${targetName} is defined more than once`);
+          } else {
+            recordAnomaly(specs, 'redefinedMember', `"${targetMember.name}" in ${targetName} duplicates a member defined in ${sourceName}`);
           }
         }
         // No need to report the same redefined member twice
@@ -404,7 +394,6 @@ function studyWebIdl(edResults, curatedResults) {
       }
     }
   }
-
 
   edResults
     // We're only interested in specs that define Web IDL content
@@ -416,9 +405,8 @@ function studyWebIdl(edResults, curatedResults) {
       try {
         const ast = WebIDL2.parse(spec.idl);
         return { spec, ast };
-      }
-      catch (e) {
-        recordAnomaly(spec, "invalid", e.message);
+      } catch (e) {
+        recordAnomaly(spec, 'invalid', e.message);
         // Use fallback from curated version if available
         // This avoids reporting errors e.g. of not-really unknown interfaces
         try {
@@ -435,39 +423,37 @@ function studyWebIdl(edResults, curatedResults) {
 
     // Populate internal indexes from AST trees
     .forEach(({ spec, ast }) => {
-      for (let dfn of ast) {
+      for (const dfn of ast) {
         if (dfn.name) {
           // Basically all definitions except includes statements:
           // https://webidl.spec.whatwg.org/#index-prod-Definition
           if (!dfns[dfn.name]) {
             dfns[dfn.name] = [];
           }
-          dfns[dfn.name].push({spec, idl: dfn});
+          dfns[dfn.name].push({ spec, idl: dfn });
           let globalEA;
-          if (dfn.type === "interface" && (globalEA = dfn?.extAttrs?.find(ea => ea.name === "Global"))) {
+          if (dfn.type === 'interface' && (globalEA = dfn?.extAttrs?.find(ea => ea.name === 'Global'))) {
             // mostly copied from webidlpedia - DRY?
-            const globalValues = Array.isArray(globalEA.rhs.value) ? globalEA.rhs.value.map(({value}) => value) : [globalEA.rhs.value];
-            for (const value of globalValues)  {
+            const globalValues = Array.isArray(globalEA.rhs.value) ? globalEA.rhs.value.map(({ value }) => value) : [globalEA.rhs.value];
+            for (const value of globalValues) {
               // "*" is not a name
-              if (value === "*") break;
+              if (value === '*') break;
               if (!globals[value]) {
-                globals[value] = {components: []};
+                globals[value] = { components: [] };
               }
               globals[value].components.push(dfn.name);
             }
           }
           parseIdlNode(dfn, spec);
-        }
-        else if (dfn.type === "includes") {
+        } else if (dfn.type === 'includes') {
           // Includes statement:
           // https://webidl.spec.whatwg.org/#index-prod-IncludesStatement
           const key = `${dfn.target} includes ${dfn.includes}`;
           if (!includesStatements[key]) {
             includesStatements[key] = [];
-             }
-          includesStatements[key].push({spec, idl: dfn});
-        }
-        else {
+          }
+          includesStatements[key].push({ spec, idl: dfn });
+        } else {
           // Apart from includes statements, all valid Web IDL definitions have
           // a name. We should only ever reach this point if the WebIDL parser
           // has a bug or if the WebIDL grammar starts supporting a new type of
@@ -490,29 +476,27 @@ function studyWebIdl(edResults, curatedResults) {
 
   // Time to run checks on IDL definitions
   for (const name in dfns) {
-    const types = new Set(dfns[name].map(({idl}) => idl.type));
+    const types = new Set(dfns[name].map(({ idl }) => idl.type));
     const specs = getSpecs(dfns[name]);
     if (types.size > 1) {
-      recordAnomaly(specs, "redefinedWithDifferentTypes", `"${name}" is defined multiple times with different types (${[...types].join(', ')}) in ${specs.map(specName).join(', ')}`);
+      recordAnomaly(specs, 'redefinedWithDifferentTypes', `"${name}" is defined multiple times with different types (${[...types].join(', ')}) in ${specs.map(specName).join(', ')}`);
       continue;
     }
     const type = [...types][0];
     let mainDef;
-    const allowPartials = ["interface", "dictionary", "namespace", "interface mixin"];
+    const allowPartials = ['interface', 'dictionary', 'namespace', 'interface mixin'];
     if (allowPartials.includes(type)) {
-      const mainDefs = dfns[name].filter(({idl}) => !idl.partial);
+      const mainDefs = dfns[name].filter(({ idl }) => !idl.partial);
       if (mainDefs.length === 0) {
-        recordAnomaly(specs, "noOriginalDefinition", `"${name}" is only defined as a partial ${type} (in ${specs.map(specName).join(', ')})`);
+        recordAnomaly(specs, 'noOriginalDefinition', `"${name}" is only defined as a partial ${type} (in ${specs.map(specName).join(', ')})`);
         continue;
-      }
-      else if (mainDefs.length > 1) {
-        recordAnomaly(getSpecs(mainDefs), "redefined", `"${name}" is defined as a non-partial ${type} mutiple times in ${getSpecs(mainDefs).map(specName).join(', ')}`);
+      } else if (mainDefs.length > 1) {
+        recordAnomaly(getSpecs(mainDefs), 'redefined', `"${name}" is defined as a non-partial ${type} mutiple times in ${getSpecs(mainDefs).map(specName).join(', ')}`);
       }
       mainDef = mainDefs[0].idl;
-    }
-    else {
+    } else {
       if (dfns[name].length > 1) {
-        recordAnomaly(dfns[name].map(({spec}) => spec), "redefined", `"${name}" is defined multiple times (with type ${type}) in ${specs.map(specName).join(', ')}`);
+        recordAnomaly(dfns[name].map(({ spec }) => spec), 'redefined', `"${name}" is defined multiple times (with type ${type}) in ${specs.map(specName).join(', ')}`);
       }
       mainDef = dfns[name][0].idl;
     }
@@ -520,33 +504,33 @@ function studyWebIdl(edResults, curatedResults) {
     // If Web IDL adds new kinds of definitions, we will very likely need to
     // adjust our logic. Let's not pretend that we understand new kinds
     const knownDfnKinds = new Set([
-      "callback interface",
-      "callback",
-      "dictionary",
-      "enum",
-      "interface",
-      "interface mixin",
-      "namespace",
-      "typedef"
+      'callback interface',
+      'callback',
+      'dictionary',
+      'enum',
+      'interface',
+      'interface mixin',
+      'namespace',
+      'typedef'
     ]);
     if (!knownDfnKinds.has(mainDef.type)) {
       throw new Error(`Unknown definition kind "${mainDef.type}" in parsed Web IDL: ${JSON.stringify(mainDef)}`);
     }
 
-    for (let {spec, idl} of dfns[name]) {
-      switch(idl.type) {
-      case "dictionary":
-        checkInheritance(spec, mainDef);
-        break;
-      case "interface":
-        checkEventHandlers(spec, idl, mainDef);
-        checkExposure(spec, idl, mainDef);
-        checkInheritance(spec, mainDef);
-        break;
-      case "enum":
-        checkEnumMultipleValues(spec, idl);
-        checkSyntaxOfEnumValue(spec, idl);
-        break;
+    for (const { spec, idl } of dfns[name]) {
+      switch (idl.type) {
+        case 'dictionary':
+          checkInheritance(spec, mainDef);
+          break;
+        case 'interface':
+          checkEventHandlers(spec, idl, mainDef);
+          checkExposure(spec, idl, mainDef);
+          checkInheritance(spec, mainDef);
+          break;
+        case 'enum':
+          checkEnumMultipleValues(spec, idl);
+          checkSyntaxOfEnumValue(spec, idl);
+          break;
       }
     }
   }
@@ -556,34 +540,32 @@ function studyWebIdl(edResults, curatedResults) {
     const statements = includesStatements[key];
     if (statements.length > 1) {
       const specs = getSpecs(statements);
-      recordAnomaly(specs, "redefinedIncludes", `The includes statement "${key}" is defined more than once in ${specs.map(specName).join(', ')}`);
+      recordAnomaly(specs, 'redefinedIncludes', `The includes statement "${key}" is defined more than once in ${specs.map(specName).join(', ')}`);
     }
 
     const statement = statements[0];
     includesStatements[key] = statement;
 
     // Check target exists and is an interface
+    // In theory, if target is defined, it is defined only once, but IDL may
+    // redefine it by mistake (already reported as an anomaly, no need to report
+    // it again). Let's just make sure that there is an "interface" definition.
     const target = dfns[statement.idl.target];
     if (!target) {
-      recordAnomaly(statement.spec, "unknownType", `Target "${statement.idl.target}" in includes statement "${key}" is not defined anywhere`);
-    }
-    // In theory, target is defined only once, but IDL may redefine it by
-    // mistake (already reported as an anomaly, no need to report it again).
-    // Let's just make sure that there is an "interface" definition.
-    else if (!target.find(({idl}) => idl.type === "interface")) {
-      recordAnomaly(statement.spec, "wrongKind", `Target "${statement.idl.target}" in includes statement "${key}" must be of kind "interface"`);
+      recordAnomaly(statement.spec, 'unknownType', `Target "${statement.idl.target}" in includes statement "${key}" is not defined anywhere`);
+    } else if (!target.find(({ idl }) => idl.type === 'interface')) {
+      recordAnomaly(statement.spec, 'wrongKind', `Target "${statement.idl.target}" in includes statement "${key}" must be of kind "interface"`);
     }
 
     // Check mixin exists and is an interface mixin
+    // In theory, mixin is defined only once if it exists, but IDL may redefine
+    // it by mistake (already reported as an anomaly, no need to report it
+    // again). let's just make sure that there is an "interface mixin" definition.
     const mixin = dfns[statement.idl.includes];
     if (!mixin) {
-      recordAnomaly(statement.spec, "unknownType", `Mixin "${statement.idl.includes}" in includes statement "${key}" is not defined anywhere`);
-    }
-    // In theory, mixin is defined only once, but IDL may redefine it by
-    // mistake (already reported as an anomaly, no need to report it again).
-    // let's just make sure that there is an "interface mixin" definition.
-    else if (!mixin.find(({idl}) => idl.type === "interface mixin")) {
-      recordAnomaly(statement.spec, "wrongKind", `Mixin "${statement.idl.includes}" in includes statement "${key}" must be of kind "interface mixin"`);
+      recordAnomaly(statement.spec, 'unknownType', `Mixin "${statement.idl.includes}" in includes statement "${key}" is not defined anywhere`);
+    } else if (!mixin.find(({ idl }) => idl.type === 'interface mixin')) {
+      recordAnomaly(statement.spec, 'wrongKind', `Mixin "${statement.idl.includes}" in includes statement "${key}" must be of kind "interface mixin"`);
     }
   }
 
@@ -591,25 +573,22 @@ function studyWebIdl(edResults, curatedResults) {
   for (const name in usedTypes) {
     if (!basicTypes.has(name) && !dfns[name]) {
       for (const { spec, idl } of usedTypes[name]) {
-        recordAnomaly(spec, "unknownType", `Unknown type "${name}" used in definition of "${idl.name}"`);
+        recordAnomaly(spec, 'unknownType', `Unknown type "${name}" used in definition of "${idl.name}"`);
       }
-    }
-    else if (dfns[name]) {
+    } else if (dfns[name]) {
       // Namespaces and interface mixins "do not create types".
-      const types = dfns[name].map(({idl}) => idl.type);
-      if (types.every(type => type === "namespace")) {
+      const types = dfns[name].map(({ idl }) => idl.type);
+      if (types.every(type => type === 'namespace')) {
         for (const { spec, idl } of usedTypes[name]) {
-          recordAnomaly(spec, "wrongType", `Namespace "${name}" cannot be used as a type in definition of "${idl.name}"`);
+          recordAnomaly(spec, 'wrongType', `Namespace "${name}" cannot be used as a type in definition of "${idl.name}"`);
         }
-      }
-      else if (types.every(type => type === "interface mixin")) {
+      } else if (types.every(type => type === 'interface mixin')) {
         for (const { spec, idl } of usedTypes[name]) {
-          recordAnomaly(spec, "wrongType", `Interface mixin "${name}" cannot be used as a type in definition of "${idl.name}"`);
+          recordAnomaly(spec, 'wrongType', `Interface mixin "${name}" cannot be used as a type in definition of "${idl.name}"`);
         }
-      }
-      else if (types.every(type => type === "namespace" || type === "interface mixin")) {
+      } else if (types.every(type => type === 'namespace' || type === 'interface mixin')) {
         for (const { spec, idl } of usedTypes[name]) {
-          recordAnomaly(spec, "wrongType", `Name "${name}" exists but is not a type and cannot be used in definition of "${idl.name}"`);
+          recordAnomaly(spec, 'wrongType', `Name "${name}" exists but is not a type and cannot be used in definition of "${idl.name}"`);
         }
       }
     }
@@ -619,7 +598,7 @@ function studyWebIdl(edResults, curatedResults) {
   for (const name in usedExtAttrs) {
     if (!knownExtAttrs.has(name)) {
       for (const { spec, idl } of usedExtAttrs[name]) {
-        recordAnomaly(spec, "unknownExtAttr", `Unknown extended attribute "${name}" used in definition of "${idl.name}"`);
+        recordAnomaly(spec, 'unknownExtAttr', `Unknown extended attribute "${name}" used in definition of "${idl.name}"`);
       }
     }
   }
@@ -630,18 +609,19 @@ function studyWebIdl(edResults, curatedResults) {
   // already been reported as anomalies. Here we'll consider that all
   // non-partial dfns are correct and we'll handle them separately.
   for (const name in dfns) {
-    const mainDfns = dfns[name].filter(({idl}) => !idl.partial);
+    const mainDfns = dfns[name].filter(({ idl }) => !idl.partial);
     for (const mainDfn of mainDfns) {
       // Check duplicate members within the main dfn itself
       checkMembers(mainDfn);
 
       // Find all the partials and mixins, including partial mixins, that apply
       // to the main dfn (note mixins are only for "interface" dfns)
-      const partials = dfns[name].filter((({idl}) => idl.partial && idl.type === mainDfn.idl.type));
-      const mixins = mainDfn.idl.type !== "interface" ? [] :
-        Object.keys(includesStatements)
+      const partials = dfns[name].filter(({ idl }) => idl.partial && idl.type === mainDfn.idl.type);
+      const mixins = mainDfn.idl.type !== 'interface'
+        ? []
+        : Object.keys(includesStatements)
           .filter(key => key.startsWith(`${name} includes `))
-          .map(key => dfns[includesStatements[key].idl.includes]?.filter(({idl}) => idl.type === 'interface mixin'))
+          .map(key => dfns[includesStatements[key].idl.includes]?.filter(({ idl }) => idl.type === 'interface mixin'))
           .filter(mixins => mixins?.length > 0)
           .flat();
       // Compare members of partials, mixins and main dfn separately to be able

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,20 +1,20 @@
 const requireFromWorkingDirectory = require('../lib/require-cwd');
-const { expandCrawlResult } = require("reffy");
+const { expandCrawlResult } = require('reffy');
 
-async function loadCrawlResults(edCrawlResultsPath, trCrawlResultsPath) {
+async function loadCrawlResults (edCrawlResultsPath, trCrawlResultsPath) {
   let edCrawlResults, trCrawlResults;
   try {
     edCrawlResults = requireFromWorkingDirectory(edCrawlResultsPath);
-  } catch(e) {
-    throw "Impossible to read " + edCrawlResultsPath + ": " + e;
+  } catch (e) {
+    throw new Error('Impossible to read ' + edCrawlResultsPath + ': ' + e);
   }
   edCrawlResults = await expandCrawlResult(edCrawlResults, edCrawlResultsPath.replace(/index\.json$/, ''));
 
   if (trCrawlResultsPath) {
     try {
       trCrawlResults = requireFromWorkingDirectory(trCrawlResultsPath);
-    } catch(e) {
-      throw "Impossible to read " + trCrawlResultsPath + ": " + e;
+    } catch (e) {
+      throw new Error('Impossible to read ' + trCrawlResultsPath + ': ' + e);
     }
     trCrawlResults = await expandCrawlResult(trCrawlResults, trCrawlResultsPath.replace(/index\.json$/, ''));
   }
@@ -25,10 +25,10 @@ async function loadCrawlResults(edCrawlResultsPath, trCrawlResultsPath) {
   };
 }
 
-function recordCategorizedAnomaly(report, category, possibleAnomalies) {
-  return function recordAnomaly(specs, name, message) {
+function recordCategorizedAnomaly (report, category, possibleAnomalies) {
+  return function recordAnomaly (specs, name, message) {
     if (!specs) {
-      throw new Error(`Cannot record an anomaly without also recording an offending spec`);
+      throw new Error('Cannot record an anomaly without also recording an offending spec');
     }
     specs = Array.isArray(specs) ? specs : [specs];
     specs = [...new Set(specs)];

--- a/src/reporting/file-issue-for-review.js
+++ b/src/reporting/file-issue-for-review.js
@@ -3,16 +3,17 @@
    and submits as a pull request in this repo if no existing one matches
 */
 const { loadCrawlResults } = require('../lib/util');
-const {studyBackrefs } = require("../lib/study-backrefs");
-const path = require("path");
-const fs = require("fs").promises;
+const { studyBackrefs } = require('../lib/study-backrefs');
+const path = require('path');
+const fs = require('fs').promises;
 const { execSync } = require('child_process');
-const Octokit = require("../lib/octokit");
+const Octokit = require('../lib/octokit');
 const matter = require('gray-matter');
+const fetch = require('node-fetch');
 
 const GH_TOKEN = (() => {
   try {
-    return require("../config.json").GH_TOKEN;
+    return require('../config.json').GH_TOKEN;
   } catch (err) {
     return process.env.GH_TOKEN;
   }
@@ -24,41 +25,43 @@ const repoOwner = 'w3c';
 const repoName = 'strudy';
 
 const octokit = new Octokit({
-  auth: GH_TOKEN,
-  //log: console
+  auth: GH_TOKEN
+  // log: console
 });
 
 // based on `jq .[].nightly.repository index.json |sort|uniq -c|sort -rn|less`
 // in browser-specs
 // TODO: automate it?
-const multiSpecRepos = ["w3c/csswg-drafts", "w3c/fxtf-drafts", "w3c/svgwg", "KhronosGroup/WebGL", "httpwg/httpwg.github.io", "w3c/css-houdini-drafts", "WebAssembly/spec", "w3c/woff", "w3c/mediacapture-handle", "w3c/epub-specs", "gpuweb/gpuweb"].map(r => "https://github.com/" + r);
+const multiSpecRepos = ['w3c/csswg-drafts', 'w3c/fxtf-drafts', 'w3c/svgwg', 'KhronosGroup/WebGL', 'httpwg/httpwg.github.io', 'w3c/css-houdini-drafts', 'WebAssembly/spec', 'w3c/woff', 'w3c/mediacapture-handle', 'w3c/epub-specs', 'gpuweb/gpuweb'].map(r => 'https://github.com/' + r);
 
-function issueWrapper(spec, anomalies, anomalyType) {
-  const titlePrefix = (multiSpecRepos.includes(spec.nightly.repository)) ? `[${spec.shortname}] ` : "";
-  let anomalyReport = "", title = "";
-  switch(anomalyType) {
-  case "brokenLinks":
-    title = `Broken references in ${spec.title}`;
-    anomalyReport = "the following links to other specifications were detected as pointing to non-existing anchors";
-    break;
-  case "outdatedSpecs":
-    title = `Outdated references in ${spec.title}`;
-    anomalyReport = "the following links were detected as pointing to outdated specifications";
-  case "nonCanonicalRefs":
-    title = `Non-canonical references in ${spec.title}`;
-    anomalyReport = "the following links were detected as pointing to outdated URLs";
+function issueWrapper (spec, anomalies, anomalyType) {
+  const titlePrefix = (multiSpecRepos.includes(spec.nightly.repository)) ? `[${spec.shortname}] ` : '';
+  let anomalyReport = ''; let title = '';
+  switch (anomalyType) {
+    case 'brokenLinks':
+      title = `Broken references in ${spec.title}`;
+      anomalyReport = 'the following links to other specifications were detected as pointing to non-existing anchors';
+      break;
+    case 'outdatedSpecs':
+      title = `Outdated references in ${spec.title}`;
+      anomalyReport = 'the following links were detected as pointing to outdated specifications';
+      break;
+    case 'nonCanonicalRefs':
+      title = `Non-canonical references in ${spec.title}`;
+      anomalyReport = 'the following links were detected as pointing to outdated URLs';
+      break;
   }
   return {
     title: titlePrefix + title,
     content: `
 While crawling [${spec.title}](${spec.crawled}), ${anomalyReport}:
-${anomalies.map(anomaly => `* [ ] ${anomaly.message}`).join("\n")}
+${anomalies.map(anomaly => `* [ ] ${anomaly.message}`).join('\n')}
 
 <sub>This issue was detected and reported semi-automatically by [Strudy](https://github.com/w3c/strudy/) based on data collected in [webref](https://github.com/w3c/webref/).</sub>`
   };
 }
 
-function prWrapper(title, uri, repo, issueReport) {
+function prWrapper (title, uri, repo, issueReport) {
   return `This pull request was automatically created by Strudy upon detecting errors in ${title}.
 
 Please check that these errors were correctly detected, and that they have not already been reported in ${repo}.
@@ -70,26 +73,25 @@ ${issueReport}
 }
 
 if (require.main === module) {
-  const knownAnomalyTypes = ["brokenLinks", "outdatedSpecs", "nonCanonicalRefs"];
+  const knownAnomalyTypes = ['brokenLinks', 'outdatedSpecs', 'nonCanonicalRefs'];
 
   let edCrawlResultsPath = process.argv[2];
   let trCrawlResultsPath = process.argv[3];
-  const anomalyFilter = process.argv.slice(4).filter(p => !p.startsWith("--"));
+  const anomalyFilter = process.argv.slice(4).filter(p => !p.startsWith('--'));
   const unknownAnomalyType = anomalyFilter.find(p => !knownAnomalyTypes.includes(p));
   if (unknownAnomalyType) {
-    console.error(`Unknown report type ${unknownAnomalyType} - known types are ${knownAnomalyTypes.join(", ")}`);
+    console.error(`Unknown report type ${unknownAnomalyType} - known types are ${knownAnomalyTypes.join(', ')}`);
     process.exit(1);
   }
   const anomalyTypes = anomalyFilter.length ? anomalyFilter : knownAnomalyTypes;
-  const updateMode = process.argv.includes("--update") ? "update-untracked" : (process.argv.includes("--update-tracked") ? "update-tracked" : false);
-  const dryRun = process.argv.includes("--dry-run");
-  const noGit = dryRun || updateMode || process.argv.includes("--no-git");
+  const updateMode = process.argv.includes('--update') ? 'update-untracked' : (process.argv.includes('--update-tracked') ? 'update-tracked' : false);
+  const dryRun = process.argv.includes('--dry-run');
+  const noGit = dryRun || updateMode || process.argv.includes('--no-git');
 
   if (!noGit && !GH_TOKEN) {
-    console.error("GH_TOKEN must be set to some personal access token as an env variable or in a config.json file");
+    console.error('GH_TOKEN must be set to some personal access token as an env variable or in a config.json file');
     process.exit(1);
   }
-
 
   // Target the index file if needed
   if (!edCrawlResultsPath.endsWith('index.json')) {
@@ -98,44 +100,43 @@ if (require.main === module) {
   if (!trCrawlResultsPath.endsWith('index.json')) {
     trCrawlResultsPath = path.join(trCrawlResultsPath, 'index.json');
   }
-  (async function() {
+  (async function () {
     let existingReports = [];
     if (updateMode) {
-      console.log(`Compiling list of relevant existing issue reports…`);
+      console.log('Compiling list of relevant existing issue reports…');
       // List all existing reports to serve as a comparison point
       // to detect if any report can be deleted
       // if the anomalies are no longer reported
-      const reportFiles = (await fs.readdir('issues')).map(p => 'issues/' + p);;
-      for (let anomalyType of anomalyTypes) {
+      const reportFiles = (await fs.readdir('issues')).map(p => 'issues/' + p);
+      for (const anomalyType of anomalyTypes) {
         existingReports = existingReports.concat(reportFiles.filter(p => p.endsWith(`-${anomalyType.toLowerCase()}.md`)));
       }
-      console.log("- done");
+      console.log('- done');
     }
     const nolongerRelevantReports = new Set(existingReports);
-
 
     // Donwload automatic map of multipages anchors in HTML spec
     let htmlFragments = {};
     try {
-      console.log("Downloading HTML spec fragments data…");
-      htmlFragments = await fetch("https://html.spec.whatwg.org/multipage/fragment-links.json").then(r => r.json());
-      console.log("- done");
+      console.log('Downloading HTML spec fragments data…');
+      htmlFragments = await fetch('https://html.spec.whatwg.org/multipage/fragment-links.json').then(r => r.json());
+      console.log('- done');
     } catch (err) {
-      console.log("- failed: could not fetch HTML fragments data, may report false positive broken links on HTML spec");
+      console.log('- failed: could not fetch HTML fragments data, may report false positive broken links on HTML spec');
     }
 
     console.log(`Opening crawl results ${edCrawlResultsPath} and ${trCrawlResultsPath}…`);
     const crawl = await loadCrawlResults(edCrawlResultsPath, trCrawlResultsPath);
-    console.log("- done");
-    console.log("Running back references analysis…");
+    console.log('- done');
+    console.log('Running back references analysis…');
     const results = studyBackrefs(crawl.ed, crawl.tr, htmlFragments);
-    console.log("- done");
+    console.log('- done');
     const currentBranch = noGit || execSync('git branch --show-current', { encoding: 'utf8' }).trim();
     const needsPush = {};
     for (const anomalyType of anomalyTypes) {
       const anomalies = results.filter(r => r.name === anomalyType);
       const specs = [...new Set(anomalies.map(a => a.specs.map(s => s.url)).flat())];
-      for (let url of specs) {
+      for (const url of specs) {
         const specAnomalies = anomalies.filter(a => a.specs[0].url === url);
         const spec = specAnomalies[0].specs[0];
         console.log(`Compiling ${anomalyType} report for ${spec.title}…`);
@@ -147,7 +148,7 @@ if (require.main === module) {
         const issueMoniker = `${spec.shortname}-${anomalyType.toLowerCase()}`;
         // is there already a file with that moniker?
         const issueFilename = path.join('issues/', issueMoniker + '.md');
-        let tracked = "N/A";
+        let tracked = 'N/A';
         let existingReportContent;
         try {
           if (!(await fs.stat(issueFilename)).isFile()) {
@@ -160,16 +161,16 @@ if (require.main === module) {
             } else {
               nolongerRelevantReports.delete(issueFilename);
               try {
-                const existingReport = matter(await fs.readFile(issueFilename, "utf-8"));
+                const existingReport = matter(await fs.readFile(issueFilename, 'utf-8'));
                 tracked = existingReport.data.Tracked;
                 existingReportContent = existingReport.content;
                 // only update tracked or untracked reports based on
                 // CLI parameter
-                if ((updateMode === "update-untracked" && tracked !== "N/A") || (updateMode === "update-tracked" && tracked === "N/A")) {
+                if ((updateMode === 'update-untracked' && tracked !== 'N/A') || (updateMode === 'update-tracked' && tracked === 'N/A')) {
                   continue;
                 }
               } catch (e) {
-                console.error("Failed to parse existing content", e);
+                console.error('Failed to parse existing content', e);
                 continue;
               }
             }
@@ -179,10 +180,10 @@ if (require.main === module) {
         }
         // if not, we create the file, add it in a branch
         // and submit it as a pull request to the repo
-        const {title, content: issueReportContent} = issueWrapper(spec, specAnomalies, anomalyType);
+        const { title, content: issueReportContent } = issueWrapper(spec, specAnomalies, anomalyType);
         if (updateMode) {
           if (existingReportContent) {
-            const existingAnomalies = existingReportContent.split("\n").filter(l => l.startsWith("* [ ] ")).map(l => l.slice(6));
+            const existingAnomalies = existingReportContent.split('\n').filter(l => l.startsWith('* [ ] ')).map(l => l.slice(6));
             if (existingAnomalies.every((a, i) => specAnomalies[i] === a) && existingAnomalies.length === specAnomalies.length) {
               // no substantial change, skip
               console.log(`Skipping ${title}, no change`);
@@ -205,7 +206,7 @@ if (require.main === module) {
         } catch (err) {
           console.error(`Failed to stringify report of ${anomalyType} for ${title}: ${err}`, issueReportContent);
           continue;
-        };
+        }
         if (dryRun) {
           console.log(`Would add ${issueFilename} with`);
           console.log(issueReport);
@@ -218,8 +219,8 @@ if (require.main === module) {
               execSync(`git checkout -b ${issueMoniker}`);
               execSync(`git add ${issueFilename}`);
               execSync(`git commit -m "File report on ${issueReportData.data.Title}"`);
-              needsPush[issueMoniker] = {title: issueReportData.data.Title, report: issueReport, repo: spec.nightly.repository, specTitle: spec.title, uri: spec.crawled, repo: spec.nightly.repository};
-              console.log("- done");
+              needsPush[issueMoniker] = { title: issueReportData.data.Title, report: issueReport, repo: spec.nightly.repository, specTitle: spec.title, uri: spec.crawled };
+              console.log('- done');
               execSync(`git checkout ${currentBranch}`);
             }
           } catch (err) {
@@ -231,24 +232,24 @@ if (require.main === module) {
       }
     }
     if (nolongerRelevantReports.size) {
-      console.log("The following reports are no longer relevant, deleting them", [...nolongerRelevantReports]);
+      console.log('The following reports are no longer relevant, deleting them', [...nolongerRelevantReports]);
       for (const issueFilename of nolongerRelevantReports) {
         await fs.unlink(issueFilename);
       }
     }
     if (Object.keys(needsPush).length) {
       let counter = 0;
-      for (let branch in needsPush) {
+      for (const branch in needsPush) {
         if (counter > MAX_PR_BY_RUN) {
           delete needsPush[branch];
           continue;
         }
 
         // is there already a pull request targetting that branch?
-        const {data: pullrequests} = (await octokit.rest.pulls.list({
-        owner: repoOwner,
-        repo: repoName,
-        head: `${repoOwner}:${branch}`
+        const { data: pullrequests } = (await octokit.rest.pulls.list({
+          owner: repoOwner,
+          repo: repoName,
+          head: `${repoOwner}:${branch}`
         }));
         if (pullrequests.length > 0) {
           console.log(`A pull request from branch ${branch} already exists, bailing`);
@@ -260,9 +261,9 @@ if (require.main === module) {
     if (Object.keys(needsPush).length) {
       console.log(`Pushing new branches ${Object.keys(needsPush).join(' ')}…`);
       execSync(`git push origin ${Object.keys(needsPush).join(' ')}`);
-      console.log("- done");
-      for (let branch in needsPush) {
-        const {title, specTitle, uri, repo, report} = needsPush[branch];
+      console.log('- done');
+      for (const branch in needsPush) {
+        const { title, specTitle, uri, repo, report } = needsPush[branch];
         console.log(`Creating pull request from branch ${branch}…`);
         await octokit.rest.pulls.create({
           owner: repoOwner,
@@ -270,9 +271,9 @@ if (require.main === module) {
           title,
           body: prWrapper(specTitle, uri, repo, report),
           head: `${repoOwner}:${branch}`,
-          base: 'main',
+          base: 'main'
         });
-        console.log("- done");
+        console.log('- done');
       }
     }
   })();

--- a/src/reporting/submit-issue.js
+++ b/src/reporting/submit-issue.js
@@ -3,87 +3,85 @@
    Can also be called on a specific issue report (typicall when it gets merged in)
  */
 
-const path = require("path");
-const fs = require("fs").promises;
+const fs = require('fs').promises;
 const matter = require('gray-matter');
 const { execSync } = require('child_process');
-const Octokit = require("../lib/octokit");
+const Octokit = require('../lib/octokit');
 
 const GH_TOKEN = (() => {
   try {
-    return require("../config.json").GH_TOKEN;
+    return require('../config.json').GH_TOKEN;
   } catch (err) {
     return process.env.GH_TOKEN;
   }
 })();
 
 const octokit = new Octokit({
-  auth: GH_TOKEN,
-  //log: console
+  auth: GH_TOKEN
+  // log: console
 });
-
 
 if (require.main === module) {
   const targetIssueReport = process.argv[2];
   let issuesToSubmit = [];
-  (async function() {
-    execSync(`git pull origin main`);
+  (async function () {
+    execSync('git pull origin main');
     if (targetIssueReport) {
       try {
-	if ((await fs.stat(targetIssueReport)).isFile()) {
-	  issuesToSubmit.push(targetIssueReport);
-	} else {
-	  console.error(`${targetIssueReport} is not a file`);
-	  process.exit(2);
-	}
+        if ((await fs.stat(targetIssueReport)).isFile()) {
+          issuesToSubmit.push(targetIssueReport);
+        } else {
+          console.error(`${targetIssueReport} is not a file`);
+          process.exit(2);
+        }
       } catch (err) {
-	console.error(`${targetIssueReport} does not exist`);
-	process.exit(2);
-    }
+        console.error(`${targetIssueReport} does not exist`);
+        process.exit(2);
+      }
     } else {
       issuesToSubmit = (await fs.readdir('issues')).filter(p => p.endsWith('.md'));
     }
     let needsCommit = false;
-    for (let filename of issuesToSubmit) {
-      const issueReport = await fs.readFile(filename, "utf-8");
-      const issueData  = matter(issueReport);
-      const {data: metadata, content: body} = issueData;
+    for (const filename of issuesToSubmit) {
+      const issueReport = await fs.readFile(filename, 'utf-8');
+      const issueData = matter(issueReport);
+      const { data: metadata, content: body } = issueData;
       if (!(metadata?.Repo && metadata?.Tracked && metadata?.Title && body)) {
-	console.error(`Could not parse expected data from ${filename}.`, JSON.stringify(issueData, null, 2));
-	continue;
+        console.error(`Could not parse expected data from ${filename}.`, JSON.stringify(issueData, null, 2));
+        continue;
       }
-      if (metadata.Tracked !== "N/A") {
-	console.log(`Issue report ${filename} already filed as ${metadata.Tracked}.`);
-	continue;
+      if (metadata.Tracked !== 'N/A') {
+        console.log(`Issue report ${filename} already filed as ${metadata.Tracked}.`);
+        continue;
       }
-      const m = metadata.Repo.match(/https:\/\/github\.com\/([^\/]*)\/([^\/]*)\/?$/);
+      const m = metadata.Repo.match(/https:\/\/github\.com\/([^/]*)\/([^/]*)\/?$/);
       if (!m) {
-	console.error(`Cannot parse ${metadata.Repo} as a github repository url.`);
-	continue;
+        console.error(`Cannot parse ${metadata.Repo} as a github repository url.`);
+        continue;
       }
-      const [,owner, repo] = m;
+      const [, owner, repo] = m;
       console.log(`Submitting issue ${metadata.Title}…`);
       const ghRes = await octokit.rest.issues.create({
-	owner,
-	repo,
-	title: metadata.Title,
-	body
+        owner,
+        repo,
+        title: metadata.Title,
+        body
       });
       const issueUrl = ghRes?.data?.html_url;
       console.log(`- filed ${issueUrl}`);
       if (issueUrl) {
-	execSync(`git pull origin main`);
-	console.log(`Saving updated report to ${filename}`);
-	metadata.Tracked = issueUrl;
-	await fs.writeFile(filename, issueData.stringify(), 'utf-8');
-	console.log(issueData.stringify());
-	execSync(`git add -u ${filename}`);
-	needsCommit = true;
+        execSync('git pull origin main');
+        console.log(`Saving updated report to ${filename}`);
+        metadata.Tracked = issueUrl;
+        await fs.writeFile(filename, issueData.stringify(), 'utf-8');
+        console.log(issueData.stringify());
+        execSync(`git add -u ${filename}`);
+        needsCommit = true;
       }
     }
     if (needsCommit) {
-      execSync(`git commit -m "Update issue reports with github issue ref"`);
-      execSync(`git push origin main`);
+      execSync('git commit -m "Update issue reports with github issue ref"');
+      execSync('git push origin main');
     }
   })();
 }

--- a/test/study-backrefs.js
+++ b/test/study-backrefs.js
@@ -1,10 +1,10 @@
 /**
  * Tests the links analysis library.
  */
+/* global describe, it */
 
-const assert = require('assert').strict;
 const { studyBackrefs } = require('../src/lib/study-backrefs');
-const { assertNbAnomalies, assertAnomaly } = require("./util");
+const { assertNbAnomalies, assertAnomaly } = require('./util');
 
 const specEdUrl = 'https://w3c.github.io/spec/';
 const specEdUrl2 = 'https://w3c.github.io/spec2/';
@@ -13,62 +13,63 @@ const toTr = url => url.replace('https://w3c.github.io', 'https://www.w3.org/TR'
 
 const idsToDfns = (ids) => {
   return ids.map(id => {
-    return {href: id, access: "public"};
+    return { href: id, access: 'public' };
   });
 };
 
-function toFullIds(base, ids) {
-  return ids.map(id => base + "#" + id);
+function toFullIds (base, ids) {
+  return ids.map(id => base + '#' + id);
 }
 
-function toLinks(base, anchors) {
+function toLinks (base, anchors) {
   const ret = {};
-  ret[base] = {anchors};
+  ret[base] = { anchors };
   return ret;
 }
 
-
 const populateSpec = (url, ids, links, dfns) => {
   dfns = dfns ?? idsToDfns(ids);
-  const shortname = url.slice(0, -1).split("/").pop();
+  const shortname = url.slice(0, -1).split('/').pop();
   return {
     url: toTr(url),
     ids,
     links,
     dfns,
-    nightly : {
+    nightly: {
       url
     },
-    release : {
+    release: {
       url: toTr(url)
     },
     shortname,
-    series: { shortname}
+    series: { shortname }
   };
 };
 
-function toCrawlResults(ids, links, trIds = ids) {
-  return { ed: [ populateSpec(specEdUrl, toFullIds(specEdUrl, ids), []),
-                 populateSpec(specEdUrl2, [], toLinks(specEdUrl, links)) ],
-           tr: [ populateSpec(specEdUrl, toFullIds(specEdUrl, trIds), [])] };
+function toCrawlResults (ids, links, trIds = ids) {
+  return {
+    ed: [populateSpec(specEdUrl, toFullIds(specEdUrl, ids), []),
+      populateSpec(specEdUrl2, [], toLinks(specEdUrl, links))],
+    tr: [populateSpec(specEdUrl, toFullIds(specEdUrl, trIds), [])]
+  };
 }
 
 describe('The links analyser', () => {
   it('reports no anomaly if links are valid', () => {
-    const ids = ["validid"];
+    const ids = ['validid'];
     const crawlResult = toCrawlResults(ids, ids);
     const report = studyBackrefs(crawlResult.ed, crawlResult.tr);
     assertNbAnomalies(report, 0);
   });
 
   it('reports a broken link', () => {
-    const ids = ["validid"];
+    const ids = ['validid'];
     const crawlResult = toCrawlResults([], ids);
     const report = studyBackrefs(crawlResult.ed, crawlResult.tr);
     assertNbAnomalies(report, 1);
     assertAnomaly(report, 0, {
-      category: "links",
-      message: specEdUrl + "#" + ids[0]
+      category: 'links',
+      message: specEdUrl + '#' + ids[0]
     });
   });
 
@@ -82,6 +83,4 @@ describe('The links analyser', () => {
     "outdatedSpecs",
     "unknownSpecs"
   */
-
-
 });

--- a/test/study-webidl.js
+++ b/test/study-webidl.js
@@ -1,24 +1,25 @@
 /**
  * Tests the Web IDL analysis library.
+ *
  */
+/* global describe, it */
 
-const assert = require('assert').strict;
 const { studyWebIdl } = require('../src/lib/study-webidl');
-const { assertNbAnomalies, assertAnomaly } = require("./util");
+const { assertNbAnomalies, assertAnomaly } = require('./util');
 
 describe('The Web IDL analyser', () => {
   const specUrl = 'https://www.w3.org/TR/spec';
   const specUrl2 = 'https://www.w3.org/TR/spec2';
 
-  function toCrawlResult(idl, idlSpec2) {
-    const crawlResult = [ { url: specUrl, idl } ];
+  function toCrawlResult (idl, idlSpec2) {
+    const crawlResult = [{ url: specUrl, idl }];
     if (idlSpec2) {
       crawlResult.push({ url: specUrl2, idl: idlSpec2 });
     }
     return crawlResult;
   }
 
-  function analyzeIdl(idl, idlSpec2) {
+  function analyzeIdl (idl, idlSpec2) {
     const crawlResult = toCrawlResult(idl, idlSpec2);
     return studyWebIdl(crawlResult);
   }
@@ -30,7 +31,6 @@ interface Valid {};
 `);
     assertNbAnomalies(report, 0);
   });
-
 
   it('reports invalid IDL', () => {
     const report = analyzeIdl(`
@@ -44,7 +44,7 @@ interface Invalid;
       message: `Syntax error at line 3, since \`interface Invalid\`:
 interface Invalid;
                  ^ Bodyless interface`,
-      specs: [ { url: specUrl }]
+      specs: [{ url: specUrl }]
     });
   });
 
@@ -67,7 +67,6 @@ interface Invalid{};
     assertAnomaly(report, 0, { name: 'invalid' });
   });
 
-
   it('forgets about previous results', () => {
     analyzeIdl(`
 [Global=Window,Exposed=*]
@@ -80,7 +79,6 @@ interface Valid {};
     assertNbAnomalies(report, 0);
   });
 
-
   it('detects missing [Exposed] extended attributes', () => {
     const report = analyzeIdl(`
 interface Unexposed {};
@@ -91,7 +89,6 @@ interface Unexposed {};
       message: 'The interface "Unexposed" has no [Exposed] extended attribute'
     });
   });
-
 
   it('detects unknown [Exposed] extended attributes', () => {
     const report = analyzeIdl(`
@@ -123,7 +120,6 @@ interface EventTarget {};
     assertNbAnomalies(report, 0);
   });
 
-
   it('detects unexpected EventHandler attributes', () => {
     const report = analyzeIdl(`
 [Exposed=*]
@@ -143,7 +139,6 @@ interface Carlos {
       message: 'The interface "Carlos" defines an event handler "onbigbisous" but does not inherit from EventTarget'
     });
   });
-
 
   it('detects incompatible partial exposure issues', () => {
     const report = analyzeIdl(`
@@ -171,7 +166,6 @@ partial interface MyPlace {};
     });
   });
 
-
   it('detects incompatible partial exposure issues when "*" is used', () => {
     const report = analyzeIdl(`
 [Global=Somewhere,Exposed=Somewhere]
@@ -189,7 +183,6 @@ partial interface Somewhere {};
     });
   });
 
-
   it('detects IDL names that are redefined across specs', () => {
     const report = analyzeIdl(`
 // IDL in first spec
@@ -206,10 +199,9 @@ dictionary GrandBob {
     assertAnomaly(report, 0, {
       name: 'redefined',
       message: `"GrandBob" is defined as a non-partial dictionary mutiple times in ${specUrl}, ${specUrl2}`,
-      specs: [ { url: specUrl }, { url: specUrl2 }]
+      specs: [{ url: specUrl }, { url: specUrl2 }]
     });
   });
-
 
   it('detects IDL names that are redefined with different types across specs', () => {
     const report = analyzeIdl(`
@@ -227,10 +219,9 @@ enum GrandBob {
     assertAnomaly(report, 0, {
       name: 'redefinedWithDifferentTypes',
       message: `"GrandBob" is defined multiple times with different types (dictionary, enum) in ${specUrl}, ${specUrl2}`,
-      specs: [ { url: specUrl }, { url: specUrl2 }]
+      specs: [{ url: specUrl }, { url: specUrl2 }]
     });
   });
-
 
   it('detects the lack of original definition for partials', () => {
     const report = analyzeIdl(`
@@ -243,7 +234,6 @@ partial interface MyPlace {};
     });
   });
 
-
   it('alerts about single enum values', () => {
     const report = analyzeIdl(`
 enum SingleValue {
@@ -253,10 +243,9 @@ enum SingleValue {
     assertNbAnomalies(report, 1);
     assertAnomaly(report, 0, {
       name: 'singleEnumValue',
-      message: `The enum "SingleValue" has fewer than 2 possible values`
+      message: 'The enum "SingleValue" has fewer than 2 possible values'
     });
   });
-
 
   it('alerts when enum values do not follow casing conventions', () => {
     const report = analyzeIdl(`
@@ -270,14 +259,13 @@ enum WrongCase {
     assertNbAnomalies(report, 2);
     assertAnomaly(report, 0, {
       name: 'wrongCaseEnumValue',
-      message: `The value "NotGood" of the enum "WrongCase" does not match the expected conventions (lower case, hyphen separated words)`
+      message: 'The value "NotGood" of the enum "WrongCase" does not match the expected conventions (lower case, hyphen separated words)'
     });
     assertAnomaly(report, 1, {
       name: 'wrongCaseEnumValue',
-      message: `The value "not_good" of the enum "WrongCase" does not match the expected conventions (lower case, hyphen separated words)`
+      message: 'The value "not_good" of the enum "WrongCase" does not match the expected conventions (lower case, hyphen separated words)'
     });
   });
-
 
   it('alerts on redefined includes statements', () => {
     const report = analyzeIdl(`
@@ -296,7 +284,6 @@ MyHome includes MyRoom;
     });
   });
 
-
   it('checks existence of target and mixin in includes statements', () => {
     const report = analyzeIdl(`
 MyHome includes MyRoom;
@@ -304,11 +291,11 @@ MyHome includes MyRoom;
     assertNbAnomalies(report, 2);
     assertAnomaly(report, 0, {
       name: 'unknownType',
-      message: `Target "MyHome" in includes statement "MyHome includes MyRoom" is not defined anywhere`
+      message: 'Target "MyHome" in includes statement "MyHome includes MyRoom" is not defined anywhere'
     });
     assertAnomaly(report, 1, {
       name: 'unknownType',
-      message: `Mixin "MyRoom" in includes statement "MyHome includes MyRoom" is not defined anywhere`
+      message: 'Mixin "MyRoom" in includes statement "MyHome includes MyRoom" is not defined anywhere'
     });
   });
 
@@ -322,14 +309,13 @@ MyHome includes MyRoom;
     assertNbAnomalies(report, 2);
     assertAnomaly(report, 0, {
       name: 'wrongKind',
-      message: `Target "MyHome" in includes statement "MyHome includes MyRoom" must be of kind "interface"`
+      message: 'Target "MyHome" in includes statement "MyHome includes MyRoom" must be of kind "interface"'
     });
     assertAnomaly(report, 1, {
       name: 'wrongKind',
-      message: `Mixin "MyRoom" in includes statement "MyHome includes MyRoom" must be of kind "interface mixin"`
+      message: 'Mixin "MyRoom" in includes statement "MyHome includes MyRoom" must be of kind "interface mixin"'
     });
   });
-
 
   it('checks inheritance', () => {
     const report = analyzeIdl(`
@@ -341,14 +327,13 @@ dictionary MyShelf : MyHome { required boolean full; };
     assertNbAnomalies(report, 2);
     assertAnomaly(report, 0, {
       name: 'unknownType',
-      message: `"MyLivingRoom" inherits from "MyRoom" which is not defined anywhere`
+      message: '"MyLivingRoom" inherits from "MyRoom" which is not defined anywhere'
     });
     assertAnomaly(report, 1, {
       name: 'wrongKind',
-      message: `"MyShelf" is of kind "dictionary" but inherits from "MyHome" which is of kind "interface"`
+      message: '"MyShelf" is of kind "dictionary" but inherits from "MyHome" which is of kind "interface"'
     });
   });
-
 
   it('reports unknown types', () => {
     const report = analyzeIdl(`
@@ -363,22 +348,21 @@ dictionary MyShelf : MyHome { required boolean full; };
     assertNbAnomalies(report, 4);
     assertAnomaly(report, 0, {
       name: 'unknownType',
-      message: `Unknown type "bool" used in definition of "MyRoom"`
+      message: 'Unknown type "bool" used in definition of "MyRoom"'
     });
     assertAnomaly(report, 1, {
       name: 'unknownType',
-      message: `Unknown type "MyBed" used in definition of "MyRoom"`
+      message: 'Unknown type "MyBed" used in definition of "MyRoom"'
     });
     assertAnomaly(report, 2, {
       name: 'unknownType',
-      message: `Unknown type "MyUnknownType" used in definition of "MyRoom"`
+      message: 'Unknown type "MyUnknownType" used in definition of "MyRoom"'
     });
     assertAnomaly(report, 3, {
       name: 'unknownType',
-      message: `Unknown type "UnknownInnerType" used in definition of "MyRoom"`
+      message: 'Unknown type "UnknownInnerType" used in definition of "MyRoom"'
     });
   });
-
 
   it('reports wrong types', () => {
     const report = analyzeIdl(`
@@ -400,18 +384,17 @@ interface mixin MyNamespaceMixin {};
     });
     assertAnomaly(report, 1, {
       name: 'wrongType',
-      message: `Namespace "MyNamespace" cannot be used as a type in definition of "MyHome"`
+      message: 'Namespace "MyNamespace" cannot be used as a type in definition of "MyHome"'
     });
     assertAnomaly(report, 2, {
       name: 'wrongType',
-      message: `Interface mixin "MyLivingRoom" cannot be used as a type in definition of "MyHome"`
+      message: 'Interface mixin "MyLivingRoom" cannot be used as a type in definition of "MyHome"'
     });
     assertAnomaly(report, 3, {
       name: 'wrongType',
-      message: `Name "MyNamespaceMixin" exists but is not a type and cannot be used in definition of "MyHome"`
+      message: 'Name "MyNamespaceMixin" exists but is not a type and cannot be used in definition of "MyHome"'
     });
   });
-
 
   it('reports unknown extended attributes', () => {
     const report = analyzeIdl(`
@@ -429,18 +412,17 @@ interface mixin MyNamespaceMixin {};
     assertNbAnomalies(report, 3);
     assertAnomaly(report, 0, {
       name: 'unknownExtAttr',
-      message: `Unknown extended attribute "UnknownExtAttr" used in definition of "MyRoom"`
+      message: 'Unknown extended attribute "UnknownExtAttr" used in definition of "MyRoom"'
     });
     assertAnomaly(report, 1, {
       name: 'unknownExtAttr',
-      message: `Unknown extended attribute "SuperUnknownExtAttr" used in definition of "MyLivingRoom"`
+      message: 'Unknown extended attribute "SuperUnknownExtAttr" used in definition of "MyLivingRoom"'
     });
     assertAnomaly(report, 2, {
       name: 'unknownExtAttr',
-      message: `Unknown extended attribute "SuperUnknownExtAttr" used in definition of "MyBedRoom"`
+      message: 'Unknown extended attribute "SuperUnknownExtAttr" used in definition of "MyBedRoom"'
     });
   });
-
 
   it('reports overloads across definitions (partial, same spec)', () => {
     const report = analyzeIdl(`
@@ -467,18 +449,17 @@ partial interface MyPartialHome {
 `);
     assertNbAnomalies(report, 2);
     assertAnomaly(report, 0, {
-    name: 'overloaded',
-    message: '"operation overload" in partial interface "MyHome" overloads an operation defined in interface "MyHome"'
-  });
+      name: 'overloaded',
+      message: '"operation overload" in partial interface "MyHome" overloads an operation defined in interface "MyHome"'
+    });
     assertAnomaly(report, 1, {
       name: 'overloaded',
       message: '"operation overload" in partial interface "MyPartialHome" overloads an operation defined in another partial interface "MyPartialHome"'
     });
   });
 
-
   it('reports overloads across definitions (partial, different specs)', () => {
-     const report = analyzeIdl(`
+    const report = analyzeIdl(`
 // IDL in first spec
 [Global=Home,Exposed=*]
 interface MyHome {
@@ -506,7 +487,7 @@ partial interface MyPartialHome {
     assertAnomaly(report, 0, {
       name: 'overloaded',
       message: `"operation overload" in partial interface "MyHome" overloads an operation defined in interface "MyHome" (in ${specUrl})`,
-      specs: [ { url: specUrl2 }]
+      specs: [{ url: specUrl2 }]
     });
 
     // No way to know which spec to blame for MyPartialHome overloads, both
@@ -514,10 +495,9 @@ partial interface MyPartialHome {
     assertAnomaly(report, 1, {
       name: 'overloaded',
       message: `"operation overload" in partial interface "MyPartialHome" (in ${specUrl2}) overloads an operation defined in another partial interface "MyPartialHome" (in ${specUrl})`,
-      specs: [ { url: specUrl2 }, { url: specUrl }]
+      specs: [{ url: specUrl2 }, { url: specUrl }]
     });
   });
-
 
   it('reports overloads across definitions (mixin, same spec)', () => {
     const report = analyzeIdl(`
@@ -541,18 +521,17 @@ partial interface mixin MyPartialRoom {
 `);
     assertNbAnomalies(report, 2);
     assertAnomaly(report, 0, {
-    name: 'overloaded',
-    message: '"operation overload" in interface "MyHome" overloads an operation defined in interface mixin "MyRoom"'
-  });
+      name: 'overloaded',
+      message: '"operation overload" in interface "MyHome" overloads an operation defined in interface mixin "MyRoom"'
+    });
     assertAnomaly(report, 1, {
       name: 'overloaded',
       message: '"operation overload" in partial interface mixin "MyPartialRoom" overloads an operation defined in interface mixin "MyPartialRoom"'
     });
   });
 
-
   it('reports overloads across definitions (mixin, different specs)', () => {
-     const report = analyzeIdl(`
+    const report = analyzeIdl(`
 // IDL in first spec
 [Global=Home,Exposed=*]
 interface MyHome {
@@ -581,28 +560,27 @@ partial interface mixin MyPartialRoom {
     assertAnomaly(report, 0, {
       name: 'overloaded',
       message: `"operation overload" in interface "MyHome" overloads an operation defined in interface mixin "MyRoom" (in ${specUrl2})`,
-      specs: [ { url: specUrl }]
+      specs: [{ url: specUrl }]
     });
 
     assertAnomaly(report, 1, {
       name: 'overloaded',
       message: '"operation overload" in partial interface mixin "MyPartialRoom" overloads an operation defined in interface mixin "MyPartialRoom"',
-      specs: [ { url: specUrl }]
+      specs: [{ url: specUrl }]
     });
 
     assertAnomaly(report, 2, {
       name: 'overloaded',
       message: `"operation overload" in partial interface mixin "MyPartialRoom" overloads an operation defined in interface mixin "MyPartialRoom" (in ${specUrl})`,
-      specs: [ { url: specUrl2 }]
+      specs: [{ url: specUrl2 }]
     });
 
     assertAnomaly(report, 3, {
       name: 'overloaded',
       message: `"operation overload" in partial interface mixin "MyPartialRoom" (in ${specUrl2}) overloads an operation defined in another partial interface mixin "MyPartialRoom" (in ${specUrl})`,
-      specs: [ { url: specUrl2 }, { url: specUrl }]
+      specs: [{ url: specUrl2 }, { url: specUrl }]
     });
   });
-
 
   it('reports overloads across definitions (partial and mixin, same spec)', () => {
     const report = analyzeIdl(`
@@ -624,9 +602,9 @@ partial interface mixin MyRoom {
 `);
     assertNbAnomalies(report, 3);
     assertAnomaly(report, 0, {
-    name: 'overloaded',
-    message: '"operation overload" in partial interface "MyHome" overloads an operation defined in interface mixin "MyRoom"'
-  });
+      name: 'overloaded',
+      message: '"operation overload" in partial interface "MyHome" overloads an operation defined in interface mixin "MyRoom"'
+    });
     assertAnomaly(report, 1, {
       name: 'overloaded',
       message: '"operation overload" in partial interface "MyHome" overloads an operation defined in partial interface mixin "MyRoom"'
@@ -636,7 +614,6 @@ partial interface mixin MyRoom {
       message: '"operation overload" in partial interface mixin "MyRoom" overloads an operation defined in interface mixin "MyRoom"'
     });
   });
-
 
   it('reports overloads across definitions (partial and mixin, different specs)', () => {
     const report = analyzeIdl(`
@@ -662,22 +639,21 @@ partial interface mixin MyRoom {
     assertAnomaly(report, 0, {
       name: 'overloaded',
       message: `"operation overload" in partial interface "MyHome" overloads an operation defined in interface mixin "MyRoom" (in ${specUrl2})`,
-      specs: [ { url: specUrl }]
+      specs: [{ url: specUrl }]
     });
 
     assertAnomaly(report, 1, {
       name: 'overloaded',
       message: `"operation overload" in partial interface "MyHome" overloads an operation defined in partial interface mixin "MyRoom" (in ${specUrl2})`,
-      specs: [ { url: specUrl }]
+      specs: [{ url: specUrl }]
     });
 
     assertAnomaly(report, 2, {
       name: 'overloaded',
       message: '"operation overload" in partial interface mixin "MyRoom" overloads an operation defined in interface mixin "MyRoom"',
-      specs: [ { url: specUrl2 }]
+      specs: [{ url: specUrl2 }]
     });
   });
-
 
   it('reports redefined members (same spec)', () => {
     const report = analyzeIdl(`
@@ -698,9 +674,9 @@ interface mixin MyRoom {
 `);
     assertNbAnomalies(report, 4);
     assertAnomaly(report, 0, {
-    name: 'redefinedMember',
-    message: '"dejaVu" in interface "MyHome" is defined more than once'
-  });
+      name: 'redefinedMember',
+      message: '"dejaVu" in interface "MyHome" is defined more than once'
+    });
     assertAnomaly(report, 1, {
       name: 'redefinedMember',
       message: '"dejaVu" in partial interface "MyHome" duplicates a member defined in interface "MyHome"'
@@ -714,7 +690,6 @@ interface mixin MyRoom {
       message: '"dejaVu" in partial interface "MyHome" duplicates a member defined in interface mixin "MyRoom"'
     });
   });
-
 
   it('reports redefined members (different specs)', () => {
     const report = analyzeIdl(`
@@ -738,19 +713,19 @@ interface mixin MyRoom {
     assertAnomaly(report, 0, {
       name: 'redefinedMember',
       message: `"dejaVu" in partial interface "MyHome" duplicates a member defined in interface "MyHome" (in ${specUrl})`,
-      specs: [ { url: specUrl2 }]
+      specs: [{ url: specUrl2 }]
     });
 
     assertAnomaly(report, 1, {
-    name: 'redefinedMember',
-    message: `"dejaVu" in interface "MyHome" duplicates a member defined in interface mixin "MyRoom" (in ${specUrl2})`,
-    specs: [ { url: specUrl }]
-  });
+      name: 'redefinedMember',
+      message: `"dejaVu" in interface "MyHome" duplicates a member defined in interface mixin "MyRoom" (in ${specUrl2})`,
+      specs: [{ url: specUrl }]
+    });
 
     assertAnomaly(report, 2, {
       name: 'redefinedMember',
       message: '"dejaVu" in partial interface "MyHome" duplicates a member defined in interface mixin "MyRoom"',
-      specs: [ { url: specUrl2 }]
+      specs: [{ url: specUrl2 }]
     });
   });
 });

--- a/test/util.js
+++ b/test/util.js
@@ -1,28 +1,26 @@
 const assert = require('assert').strict;
 
-function assertNbAnomalies(report, length) {
+function assertNbAnomalies (report, length) {
   assert.deepEqual(report.length, length,
                    `Expected ${length} anomalies but got ${report.length}. Full report received:\n` +
                    JSON.stringify(report, null, 2));
 }
 
-function assertAnomaly(report, idx, value) {
+function assertAnomaly (report, idx, value) {
   const msg = `Mismatch for anomaly at index ${idx}. Full anomaly received:\n` +
         JSON.stringify(report[idx], null, 2);
-  function assertMatch(actual, expected) {
+  function assertMatch (actual, expected) {
     if (Array.isArray(expected)) {
       assert(Array.isArray(actual), msg);
       assert.deepEqual(actual.length, expected.length, msg);
-      for (let i=0; i<expected.length; i++) {
+      for (let i = 0; i < expected.length; i++) {
         assertMatch(actual[i], expected[i]);
       }
-    }
-    else if (typeof expected === 'object') {
+    } else if (typeof expected === 'object') {
       for (const prop in expected) {
         assertMatch(actual[prop], expected[prop]);
       }
-    }
-    else {
+    } else {
       assert.deepEqual(actual, expected, msg);
     }
   }


### PR DESCRIPTION
I ran [semistandard](https://github.com/standard/semistandard) on most source files. Some of the suggested updates don't seem fantastically needed but the linter takes care of applying them.

More importantly, this proves useful to detect dangling dependency references here and there, and missing `require("node-fetch")` calls.

We may consider introducing a linter as part of CI. Just applying it once for now (and not done for all files).