### PR TITLE
Bump minimal version of Node.js from 14 to 18

### DIFF
--- a/.github/workflows/clean-reports.yml
+++ b/.github/workflows/clean-reports.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '16'
+        node-version: 18
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/file-issue-for-review.yml
+++ b/.github/workflows/file-issue-for-review.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 16
+        node-version: 18
     - name: Checkout strudy
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/submit-issue.yml
+++ b/.github/workflows/submit-issue.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 16
+        node-version: 18
     - name: Checkout strudy
       uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: 18
 
     - name: Install dependencies
       run: npm ci

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "main": "index.js",
   "bin": "./strudy.js",


### PR DESCRIPTION
The switch is needed to bump versions of a few dependencies.

Note I'm planning to release a major version of Strudy once that is merged.