### PR TITLE
Add SharedArrayBuffer to list of well-known basic types

### DIFF
--- a/src/lib/study-webidl.js
+++ b/src/lib/study-webidl.js
@@ -72,6 +72,7 @@ const basicTypes = new Set([
   'long', // https://webidl.spec.whatwg.org/#idl-long
   'object', // https://webidl.spec.whatwg.org/#idl-object
   'octet', // https://webidl.spec.whatwg.org/#idl-octet
+  'SharedArrayBuffer', // https://webidl.spec.whatwg.org/#idl-SharedArrayBuffer
   'short', // https://webidl.spec.whatwg.org/#idl-short
   'symbol', // https://webidl.spec.whatwg.org/#idl-symbol
   'BigUint64Array', // https://webidl.spec.whatwg.org/#idl-BigUint64Array


### PR DESCRIPTION
Added to WebIDL spec in https://github.com/whatwg/webidl/pull/1311 (and the spec defines a `typedef` that uses `SharedArrayBuffer`)