### PR TITLE
Adjust code to deal with spec entries without nightly URLs

### DIFF
--- a/src/lib/study-backrefs.js
+++ b/src/lib/study-backrefs.js
@@ -275,7 +275,7 @@ function studyBackrefs (edResults, trResults = [], htmlFragments = {}) {
           shortname = (edResults.find(r =>
             r.url === nakedLink ||
               (r.release && r.release.url === nakedLink) ||
-              r.nightly.url === nakedLink ||
+              (r.nightly && r.nightly.url === nakedLink) ||
               (r.series && nakedLink === `https://www.w3.org/TR/${r.series.shortname}/`)) || {}).shortname;
 
           // If it does not match any known URL, try to compute a shortname out of
@@ -350,7 +350,7 @@ function studyBackrefs (edResults, trResults = [], htmlFragments = {}) {
         // Check anchors
         const anchors = spec.links[link].anchors || [];
         for (const anchor of anchors) {
-          const baseLink = (sourceSpec.nightly.url === link || sourceSpec.nightly?.pages?.includes(link)) ? link : sourceSpec.nightly.url;
+          const baseLink = (sourceSpec.nightly?.url === link || sourceSpec.nightly?.pages?.includes(link)) ? link : sourceSpec.nightly?.url;
           const matchFullNightlyLink = matchAnchor(baseLink, anchor);
           const matchFullReleaseLink = matchAnchor((sourceSpec.release || sourceSpec.nightly).url, anchor);
           const isKnownId = ids.find(matchFullNightlyLink);

--- a/src/lib/study-refs.js
+++ b/src/lib/study-refs.js
@@ -13,7 +13,7 @@ function studyReferences (edResults) {
 
       if (referencedSpec && referencedSpec.standing === "discontinued") {
 
-	const newSpecsLinks = edResults.filter(s => referencedSpec.obsoletedBy?.includes(s.shortname)).map(s => `[${s.shortname}](${s?.nightly.url || s.url})`);
+	const newSpecsLinks = edResults.filter(s => referencedSpec.obsoletedBy?.includes(s.shortname)).map(s => `[${s.shortname}](${s?.nightly?.url || s.url})`);
 	recordAnomaly(spec, 'discontinuedReferences', `[${ref.name}](${ref.url}) ${newSpecsLinks.length ? `has been obsoleted by ${newSpecsLinks}` : `is discontinued, no known replacement reference`}`);
       }
     });

--- a/src/reporting/file-issue-for-review.js
+++ b/src/reporting/file-issue-for-review.js
@@ -148,7 +148,7 @@ if (require.main === module) {
         const spec = specAnomalies[0].specs[0];
         console.log(`Compiling ${anomalyType} report for ${spec.title}…`);
         // if we don't know the repo, we can't file an issue
-        if (!spec.nightly.repository) {
+        if (!spec.nightly?.repository) {
           console.log(`No known repo for ${spec.title}, skipping`);
           continue;
         }


### PR DESCRIPTION
This follows from the change made to browser-specs that introduces specs without a `nightly` property.