### PR TITLE
Compute multi-spec repositories automatically

### DIFF
--- a/src/lib/is-in-multi-spec-repo.js
+++ b/src/lib/is-in-multi-spec-repo.js
@@ -1,0 +1,17 @@
+/**
+ * Return true if the given spec is maintained in a GitHub repository shared
+ * with other specs.
+ *
+ * The function takes as input a list of crawled specs, typically the list
+ * of specs in the `index.json` file of a crawled report. That list contains
+ * data from browser-specs about the specs, allowing the function to answer
+ * the request.
+ */
+export default function (spec, specs) {
+  if (!spec.nightly?.repository) {
+    return false;
+  }
+  return !!specs.find(s =>
+    s.nightly?.repository === spec.nightly.repository &&
+    s.series.shortname !== spec.series.shortname);
+}


### PR DESCRIPTION
The list of multi-spec repositories was hardcoded and slightly outdated. The update now computes that list automatically from the data present in the results of the crawl (which comes from browser-specs). Compared to the previous list, the new logic misses `w3c/woff` because it voluntarily skips repositories that contain multiple versions of the same spec to avoid false positives. It adds:

https://github.com/httpwg/http-extensions
https://github.com/immersive-web/real-world-geometry https://github.com/w3c/aria
https://github.com/w3c/encrypted-media
https://github.com/w3c/gamepad
https://github.com/w3c/reporting
https://github.com/w3c/webcodecs
https://github.com/WebAssembly/threads
https://github.com/WebBluetoothCG/web-bluetooth
https://github.com/WICG/nav-speculation
https://github.com/WICG/shape-detection-api
https://github.com/WICG/WebApiDevice

Some of them contain one "main" spec and side specs that we will probably ignore for some time, but then it does not hurt to prefix issues with the spec's shortname in such cases, even if the targeted spec is somewhat obvious.