### PR TITLE
[Issue filer] Start new branches from initial one

### DIFF
--- a/src/reporting/file-issue-for-review.js
+++ b/src/reporting/file-issue-for-review.js
@@ -179,7 +179,10 @@ Usage notes for some of the options:
           (entry.action === 'update') ? 'Update' :
           'Delete';
         console.log(`- create PR for ${entry.filename}`);
-        execOrLog(`git checkout -b ${issueMoniker}`);
+        // Note: always use the initial branch as starting point
+        // otherwise commits made for files already reported would also be
+        // copied to the new branch.
+        execOrLog(`git checkout -b ${issueMoniker} ${currentBranch}`);
         execOrLog(`git add ${entry.filename}`);
         execOrLog(`git commit -m "${actionLabel} report on ${issueReport.data.Title}"`);
         execOrLog(`git push origin ${issueMoniker}`);


### PR DESCRIPTION
The code created new branches out of the last created branch, which effectively meant that the commits built up from one report to the next. This update specifies that the starting point for creating a new branch should always be the initial branch (from which we computed the list of changes).