### PR TITLE
Skip discontinued specs by default

### DIFF
--- a/src/lib/study.js
+++ b/src/lib/study.js
@@ -609,9 +609,13 @@ export default async function study(specs, options = {}) {
 
   // Only keep specs that caller wants to study
   // (but note study functions that analyze references need the whole list!)
+  // Study skips discontinued specs by default, unless they are explicitly
+  // mentioned in the list of specs to study.
   options.crawlResults = specs;
   if (options.specs) {
-    specs = options.crawlResults.filter(spec => options.specs.find(shortname => shortname === spec.shortname));
+    specs = options.crawlResults.filter(spec => options.specs.find(shortname =>
+      (shortname === 'all' && spec.standing !== 'discontinued') ||
+      shortname === spec.shortname));
   }
 
   // Anomalies are studied in groups of related anomalies, let's compute the

--- a/strudy.js
+++ b/strudy.js
@@ -67,7 +67,7 @@ program
   .option('-f, --format <format>', 'report markdown or json', 'markdown')
   .option('-i, --issues <folder>', 'report issues as markdown files in the given folder')
   .option('-m, --max <max>', 'maximum number of issue files to create/update', myParseInt, 0)
-  .option('-s, --spec <specs...>', 'restrict analysis to given specs')
+  .option('-s, --spec <specs...>', 'restrict analysis to given specs', ['all'])
   .option('--sort <sort>', 'key(s) to use to sort the structured report', 'default')
   .option('--structure <structure>', 'report structure', 'type+spec')
   .option('--tr <trreport>', 'path/URL to crawl report on published specs')
@@ -127,15 +127,20 @@ Usage notes for some of the options:
   report (see --structure).
 
 -s, --spec <specs...>
-  Valid spec values may be a shortname, a URL, or a relative path to a JSON
-  file that contains a list of spec URLs and/or shortnames. Shortnames may be
-  the shortname of the spec series.
-
-  Use "all" to include all specs. This is equivalent to not setting the option
-  at all.
+  Valid spec values are spec shortnames. Use "all" to include all specs. This
+  is equivalent to not setting the option at all.
 
   For instance:
-    $ strudy inspect . --spec picture-in-picture https://w3c.github.io/mediasession/
+    $ strudy inspect . --spec picture-in-picture
+
+  The analysis skips discontinued specs that may appear in the crawl result by
+  default. To force an analysis on a discontinued spec, mention its shortname
+  explicitly. You may combine that shortname with the value "all" to analyze
+  all non-discontinued specs plus the ones explicitly listed with their
+  shortnames.
+
+  For instance:
+    $ strudy inspect . --spec all --spec tracking-dnt
 
 --sort <sort>
   Specifies the key(s) to use to sort each level in the structured report.


### PR DESCRIPTION
Via https://github.com/w3c/strudy/pull/706#pullrequestreview-2265857575

Crawl results typically do not contain entries for discontinued specs (Reffy skips them by default), but we keep a number of them around in Webref data that may need to be referenced from other specs.

This update makes the analysis skip discontinued specs by default as well. An explicit list of shortnames of discontinued specs to analyze may be specified through the `--spec` option.

From a library perspective, not passing any `specs` option to the `study` function means that the function will analyze all specs, regardless of their standing. Otherwise, the value `"all"` is interpreted to mean "all specs except discontinued ones".

The documentation of the `--spec` option hadn't been updated and still reflected the old behaviour. The option no longer accepts URLs and series shortnames for now (although that could be re-introduced later on if that turns out to be useful).