### PR TITLE
Check spaces in enum values; more markdown-friendly messages

### DIFF
--- a/src/lib/study-webidl.js
+++ b/src/lib/study-webidl.js
@@ -23,7 +23,7 @@ import * as WebIDL2 from 'webidl2';
 
 const getSpecs = list => [...new Set(list.map(({ spec }) => spec))];
 const specName = spec => spec.shortname ?? spec.url;
-const dfnName = dfn => `${dfn.idl.partial ? 'partial ' : ''}${dfn.idl.type} "${dfn.idl.name}"`;
+const dfnName = dfn => `${dfn.idl.partial ? 'partial ' : ''}${dfn.idl.type} \`${dfn.idl.name}\``;
 
 const basicTypes = new Set([
   // Types defined by Web IDL itself:
@@ -203,7 +203,7 @@ function studyWebIdl (specs, { crawledResults = [], curatedResults = [] } = {}) 
   function checkEventHandlers (spec, memberHolder, iface = memberHolder) {
     const eventHandler = memberHolder.members.find(m => m?.name?.startsWith('on') && m.type === 'attribute' && m.idlType?.idlType === 'EventHandler');
     if (eventHandler && !inheritsFrom(iface, 'EventTarget')) {
-      recordAnomaly(spec, 'unexpectedEventHandler', `The interface "${iface.name}" defines an event handler "${eventHandler.name}" but does not inherit from EventTarget`);
+      recordAnomaly(spec, 'unexpectedEventHandler', `The interface \`${iface.name}\` defines an event handler \`${eventHandler.name}\` but does not inherit from \`EventTarget\``);
     }
   }
 
@@ -236,12 +236,12 @@ function studyWebIdl (specs, { crawledResults = [], curatedResults = [] } = {}) 
     // Make sure that the interface is defined somewhere
     const ifaceExposure = getExposure(iface);
     if (ifaceExposure.length === 0 && !iface.partial) {
-      recordAnomaly(spec, 'noExposure', `The interface "${iface.name}" has no [Exposed] extended attribute`);
+      recordAnomaly(spec, 'noExposure', `The interface \`${iface.name}\` has no \`[Exposed]\` extended attribute`);
     } else if (ifaceExposure.length > 0 && ifaceExposure[0] !== '*') {
       // Make sure that the interface is exposed on known globals
       const unknown = ifaceExposure.filter(e => !Object.keys(globals).includes(e));
       if (unknown.length > 0) {
-        recordAnomaly(spec, 'unknownExposure', `The [Exposed] extended attribute of the interface "${iface.name}" references unknown global(s): ${unknown.join(', ')}`);
+        recordAnomaly(spec, 'unknownExposure', `The \`[Exposed]\` extended attribute of the interface \`${iface.name}\` references unknown global(s): ${unknown.join(', ')}`);
       }
     }
 
@@ -249,11 +249,11 @@ function studyWebIdl (specs, { crawledResults = [], curatedResults = [] } = {}) 
     if (iface.partial) {
       const mainExposure = getExposure(mainInterface);
       if (ifaceExposure[0] === '*' && mainExposure[0] !== '*') {
-        recordAnomaly(spec, 'incompatiblePartialIdlExposure', `The partial interface "${iface.name}" is exposed on all globals but the original interface is not (${mainExposure.join(', ')})`);
+        recordAnomaly(spec, 'incompatiblePartialIdlExposure', `The partial interface \`${iface.name}\` is exposed on all globals but the original interface is not (${mainExposure.join(', ')})`);
       } else if (ifaceExposure.length > 0 && mainExposure.length > 0 && mainExposure[0] !== '*') {
         const problematic = ifaceExposure.filter(x => !mainExposure.includes(x));
         if (problematic.length > 0) {
-          recordAnomaly(spec, 'incompatiblePartialIdlExposure', `The [Exposed] extended attribute of the partial interface "${iface.name}" references globals on which the original interface is not exposed: ${problematic.join(', ')} (original exposure: ${mainExposure.join(', ')})`);
+          recordAnomaly(spec, 'incompatiblePartialIdlExposure', `The \`[Exposed]\` extended attribute of the partial interface \`${iface.name}\` references globals on which the original interface is not exposed: ${problematic.join(', ')} (original exposure: ${mainExposure.join(', ')})`);
         }
       }
     }
@@ -261,14 +261,14 @@ function studyWebIdl (specs, { crawledResults = [], curatedResults = [] } = {}) 
 
   function checkEnumMultipleValues (spec, idl) {
     if (idl.values.length <= 1) {
-      recordAnomaly(spec, 'singleEnumValue', `The enum "${idl.name}" has fewer than 2 possible values`);
+      recordAnomaly(spec, 'singleEnumValue', `The enum \`${idl.name}\` has fewer than 2 possible values`);
     }
   }
 
   function checkSyntaxOfEnumValue (spec, idl) {
     idl.values.forEach(({ value }) => {
-      if (value.match(/[A-Z_]/)) {
-        recordAnomaly(spec, 'wrongCaseEnumValue', `The value "${value}" of the enum "${idl.name}" does not match the expected conventions (lower case, hyphen separated words)`);
+      if (value.match(/[A-Z_\s]/)) {
+        recordAnomaly(spec, 'wrongCaseEnumValue', `The value \`"${value}"\` of the enum \`${idl.name}\` does not match the expected conventions (lower case, hyphen separated words)`);
       }
     });
   }
@@ -277,9 +277,9 @@ function studyWebIdl (specs, { crawledResults = [], curatedResults = [] } = {}) 
     if (!idl.inheritance) return;
     const parent = dfns[idl.inheritance];
     if (!parent) {
-      recordAnomaly(spec, 'unknownType', `"${idl.name}" inherits from "${idl.inheritance}" which is not defined anywhere`);
+      recordAnomaly(spec, 'unknownType', `\`${idl.name}\` inherits from \`${idl.inheritance}\` which is not defined anywhere`);
     } else if (parent[0].idl.type !== idl.type) {
-      recordAnomaly(spec, 'wrongKind', `"${idl.name}" is of kind "${idl.type}" but inherits from "${idl.inheritance}" which is of kind "${parent[0].idl.type}"`);
+      recordAnomaly(spec, 'wrongKind', `\`${idl.name}\` is of kind \`${idl.type}\` but inherits from \`${idl.inheritance}\` which is of kind \`${parent[0].idl.type}\``);
     }
   }
 
@@ -360,7 +360,7 @@ function studyWebIdl (specs, { crawledResults = [], curatedResults = [] } = {}) 
 
         if (isOverloadedOperation(targetMember, sourceMember)) {
           if (!selfCheck) {
-            recordAnomaly(specs, 'overloaded', `"${describeMember(targetMember)}" in ${targetName} overloads an operation defined in ${sourceName}`);
+            recordAnomaly(specs, 'overloaded', `\`${describeMember(targetMember)}\` in ${targetName} overloads an operation defined in ${sourceName}`);
           }
           break;
         }
@@ -372,9 +372,9 @@ function studyWebIdl (specs, { crawledResults = [], curatedResults = [] } = {}) 
 
         if (!knownDuplicates.includes(targetMember.name)) {
           if (selfCheck) {
-            recordAnomaly(specs, 'redefinedMember', `"${targetMember.name}" in ${targetName} is defined more than once`);
+            recordAnomaly(specs, 'redefinedMember', `\`${targetMember.name}\` in ${targetName} is defined more than once`);
           } else {
-            recordAnomaly(specs, 'redefinedMember', `"${targetMember.name}" in ${targetName} duplicates a member defined in ${sourceName}`);
+            recordAnomaly(specs, 'redefinedMember', `\`${targetMember.name}\` in ${targetName} duplicates a member defined in ${sourceName}`);
           }
         }
         // No need to report the same redefined member twice
@@ -472,7 +472,7 @@ function studyWebIdl (specs, { crawledResults = [], curatedResults = [] } = {}) 
     const types = new Set(dfns[name].map(({ idl }) => idl.type));
     const specs = getSpecs(dfns[name]);
     if (types.size > 1) {
-      recordAnomaly(specs, 'redefinedWithDifferentTypes', `"${name}" is defined multiple times with different types (${[...types].join(', ')}) in ${specs.map(specName).join(', ')}`);
+      recordAnomaly(specs, 'redefinedWithDifferentTypes', `\`${name}\` is defined multiple times with different types (${[...types].join(', ')}) in ${specs.map(specName).join(', ')}`);
       continue;
     }
     const type = [...types][0];
@@ -481,15 +481,15 @@ function studyWebIdl (specs, { crawledResults = [], curatedResults = [] } = {}) 
     if (allowPartials.includes(type)) {
       const mainDefs = dfns[name].filter(({ idl }) => !idl.partial);
       if (mainDefs.length === 0) {
-        recordAnomaly(specs, 'noOriginalDefinition', `"${name}" is only defined as a partial ${type} (in ${specs.map(specName).join(', ')})`);
+        recordAnomaly(specs, 'noOriginalDefinition', `\`${name}\` is only defined as a partial ${type} (in ${specs.map(specName).join(', ')})`);
         continue;
       } else if (mainDefs.length > 1) {
-        recordAnomaly(getSpecs(mainDefs), 'redefined', `"${name}" is defined as a non-partial ${type} mutiple times in ${getSpecs(mainDefs).map(specName).join(', ')}`);
+        recordAnomaly(getSpecs(mainDefs), 'redefined', `\`${name}\` is defined as a non-partial ${type} mutiple times in ${getSpecs(mainDefs).map(specName).join(', ')}`);
       }
       mainDef = mainDefs[0].idl;
     } else {
       if (dfns[name].length > 1) {
-        recordAnomaly(dfns[name].map(({ spec }) => spec), 'redefined', `"${name}" is defined multiple times (with type ${type}) in ${specs.map(specName).join(', ')}`);
+        recordAnomaly(dfns[name].map(({ spec }) => spec), 'redefined', `\`${name}\` is defined multiple times (with type ${type}) in ${specs.map(specName).join(', ')}`);
       }
       mainDef = dfns[name][0].idl;
     }
@@ -533,7 +533,7 @@ function studyWebIdl (specs, { crawledResults = [], curatedResults = [] } = {}) 
     const statements = includesStatements[key];
     if (statements.length > 1) {
       const specs = getSpecs(statements);
-      recordAnomaly(specs, 'redefinedIncludes', `The includes statement "${key}" is defined more than once in ${specs.map(specName).join(', ')}`);
+      recordAnomaly(specs, 'redefinedIncludes', `The includes statement \`${key}\` is defined more than once in ${specs.map(specName).join(', ')}`);
     }
 
     const statement = statements[0];
@@ -545,9 +545,9 @@ function studyWebIdl (specs, { crawledResults = [], curatedResults = [] } = {}) 
     // it again). Let's just make sure that there is an "interface" definition.
     const target = dfns[statement.idl.target];
     if (!target) {
-      recordAnomaly(statement.spec, 'unknownType', `Target "${statement.idl.target}" in includes statement "${key}" is not defined anywhere`);
+      recordAnomaly(statement.spec, 'unknownType', `Target \`${statement.idl.target}\` in includes statement \`${key}\` is not defined anywhere`);
     } else if (!target.find(({ idl }) => idl.type === 'interface')) {
-      recordAnomaly(statement.spec, 'wrongKind', `Target "${statement.idl.target}" in includes statement "${key}" must be of kind "interface"`);
+      recordAnomaly(statement.spec, 'wrongKind', `Target \`${statement.idl.target}\` in includes statement \`${key}\` must be of kind \`interface\``);
     }
 
     // Check mixin exists and is an interface mixin
@@ -556,9 +556,9 @@ function studyWebIdl (specs, { crawledResults = [], curatedResults = [] } = {}) 
     // again). let's just make sure that there is an "interface mixin" definition.
     const mixin = dfns[statement.idl.includes];
     if (!mixin) {
-      recordAnomaly(statement.spec, 'unknownType', `Mixin "${statement.idl.includes}" in includes statement "${key}" is not defined anywhere`);
+      recordAnomaly(statement.spec, 'unknownType', `Mixin \`${statement.idl.includes}\` in includes statement \`${key}\` is not defined anywhere`);
     } else if (!mixin.find(({ idl }) => idl.type === 'interface mixin')) {
-      recordAnomaly(statement.spec, 'wrongKind', `Mixin "${statement.idl.includes}" in includes statement "${key}" must be of kind "interface mixin"`);
+      recordAnomaly(statement.spec, 'wrongKind', `Mixin \`${statement.idl.includes}\` in includes statement \`${key}\` must be of kind \`interface mixin\``);
     }
   }
 
@@ -566,22 +566,22 @@ function studyWebIdl (specs, { crawledResults = [], curatedResults = [] } = {}) 
   for (const name in usedTypes) {
     if (!basicTypes.has(name) && !dfns[name]) {
       for (const { spec, idl } of usedTypes[name]) {
-        recordAnomaly(spec, 'unknownType', `Unknown type "${name}" used in definition of "${idl.name}"`);
+        recordAnomaly(spec, 'unknownType', `Unknown type \`${name}\` used in definition of \`${idl.name}\``);
       }
     } else if (dfns[name]) {
       // Namespaces and interface mixins "do not create types".
       const types = dfns[name].map(({ idl }) => idl.type);
       if (types.every(type => type === 'namespace')) {
         for (const { spec, idl } of usedTypes[name]) {
-          recordAnomaly(spec, 'wrongType', `Namespace "${name}" cannot be used as a type in definition of "${idl.name}"`);
+          recordAnomaly(spec, 'wrongType', `Namespace \`${name}\` cannot be used as a type in definition of \`${idl.name}\``);
         }
       } else if (types.every(type => type === 'interface mixin')) {
         for (const { spec, idl } of usedTypes[name]) {
-          recordAnomaly(spec, 'wrongType', `Interface mixin "${name}" cannot be used as a type in definition of "${idl.name}"`);
+          recordAnomaly(spec, 'wrongType', `Interface mixin \`${name}\` cannot be used as a type in definition of \`${idl.name}\``);
         }
       } else if (types.every(type => type === 'namespace' || type === 'interface mixin')) {
         for (const { spec, idl } of usedTypes[name]) {
-          recordAnomaly(spec, 'wrongType', `Name "${name}" exists but is not a type and cannot be used in definition of "${idl.name}"`);
+          recordAnomaly(spec, 'wrongType', `Name \`${name}\` exists but is not a type and cannot be used in definition of \`${idl.name}\``);
         }
       }
     }
@@ -591,7 +591,7 @@ function studyWebIdl (specs, { crawledResults = [], curatedResults = [] } = {}) 
   for (const name in usedExtAttrs) {
     if (!knownExtAttrs.has(name)) {
       for (const { spec, idl } of usedExtAttrs[name]) {
-        recordAnomaly(spec, 'unknownExtAttr', `Unknown extended attribute "${name}" used in definition of "${idl.name}"`);
+        recordAnomaly(spec, 'unknownExtAttr', `Unknown extended attribute \`${name}\` used in definition of \`${idl.name}\``);
       }
     }
   }

--- a/test/study-webidl.js
+++ b/test/study-webidl.js
@@ -132,7 +132,7 @@ interface Unexposed {};
     assertNbAnomalies(report, 1);
     assertAnomaly(report, 0, {
       name: 'noExposure',
-      message: 'The interface "Unexposed" has no [Exposed] extended attribute'
+      message: 'The interface `Unexposed` has no `[Exposed]` extended attribute'
     });
   });
 
@@ -144,7 +144,7 @@ interface WhereIAm {};
     assertNbAnomalies(report, 1);
     assertAnomaly(report, 0, {
       name: 'unknownExposure',
-      message: 'The [Exposed] extended attribute of the interface "WhereIAm" references unknown global(s): Unknown'
+      message: 'The `[Exposed]` extended attribute of the interface `WhereIAm` references unknown global(s): Unknown'
     });
   });
 
@@ -182,7 +182,7 @@ interface Carlos {
     assertNbAnomalies(report, 1);
     assertAnomaly(report, 0, {
       name: 'unexpectedEventHandler',
-      message: 'The interface "Carlos" defines an event handler "onbigbisous" but does not inherit from EventTarget'
+      message: 'The interface `Carlos` defines an event handler `onbigbisous` but does not inherit from `EventTarget`'
     });
   });
 
@@ -208,7 +208,7 @@ partial interface MyPlace {};
     assertNbAnomalies(report, 1);
     assertAnomaly(report, 0, {
       name: 'incompatiblePartialIdlExposure',
-      message: 'The [Exposed] extended attribute of the partial interface "MyPlace" references globals on which the original interface is not exposed: Elsewhere (original exposure: Somewhere)'
+      message: 'The `[Exposed]` extended attribute of the partial interface `MyPlace` references globals on which the original interface is not exposed: Elsewhere (original exposure: Somewhere)'
     });
   });
 
@@ -225,7 +225,7 @@ partial interface Somewhere {};
     assertNbAnomalies(report, 1);
     assertAnomaly(report, 0, {
       name: 'incompatiblePartialIdlExposure',
-      message: 'The partial interface "Somewhere" is exposed on all globals but the original interface is not (Somewhere)'
+      message: 'The partial interface `Somewhere` is exposed on all globals but the original interface is not (Somewhere)'
     });
   });
 
@@ -244,7 +244,7 @@ dictionary GrandBob {
     assertNbAnomalies(report, 1);
     assertAnomaly(report, 0, {
       name: 'redefined',
-      message: `"GrandBob" is defined as a non-partial dictionary mutiple times in ${specUrl}, ${specUrl2}`,
+      message: `\`GrandBob\` is defined as a non-partial dictionary mutiple times in ${specUrl}, ${specUrl2}`,
       specs: [{ url: specUrl }, { url: specUrl2 }]
     });
   });
@@ -264,7 +264,7 @@ enum GrandBob {
     assertNbAnomalies(report, 1);
     assertAnomaly(report, 0, {
       name: 'redefinedWithDifferentTypes',
-      message: `"GrandBob" is defined multiple times with different types (dictionary, enum) in ${specUrl}, ${specUrl2}`,
+      message: `\`GrandBob\` is defined multiple times with different types (dictionary, enum) in ${specUrl}, ${specUrl2}`,
       specs: [{ url: specUrl }, { url: specUrl2 }]
     });
   });
@@ -276,7 +276,7 @@ partial interface MyPlace {};
     assertNbAnomalies(report, 1);
     assertAnomaly(report, 0, {
       name: 'noOriginalDefinition',
-      message: `"MyPlace" is only defined as a partial interface (in ${specUrl})`
+      message: `\`MyPlace\` is only defined as a partial interface (in ${specUrl})`
     });
   });
 
@@ -289,7 +289,7 @@ enum SingleValue {
     assertNbAnomalies(report, 1);
     assertAnomaly(report, 0, {
       name: 'singleEnumValue',
-      message: 'The enum "SingleValue" has fewer than 2 possible values'
+      message: 'The enum `SingleValue` has fewer than 2 possible values'
     });
   });
 
@@ -299,17 +299,22 @@ enum WrongCase {
   "good",
   "NotGood",
   "very-good",
-  "not_good"
+  "not_good",
+  "not good either"
 };
 `);
-    assertNbAnomalies(report, 2);
+    assertNbAnomalies(report, 3);
     assertAnomaly(report, 0, {
       name: 'wrongCaseEnumValue',
-      message: 'The value "NotGood" of the enum "WrongCase" does not match the expected conventions (lower case, hyphen separated words)'
+      message: 'The value `"NotGood"` of the enum `WrongCase` does not match the expected conventions (lower case, hyphen separated words)'
     });
     assertAnomaly(report, 1, {
       name: 'wrongCaseEnumValue',
-      message: 'The value "not_good" of the enum "WrongCase" does not match the expected conventions (lower case, hyphen separated words)'
+      message: 'The value `"not_good"` of the enum `WrongCase` does not match the expected conventions (lower case, hyphen separated words)'
+    });
+    assertAnomaly(report, 2, {
+      name: 'wrongCaseEnumValue',
+      message: 'The value `"not good either"` of the enum `WrongCase` does not match the expected conventions (lower case, hyphen separated words)'
     });
   });
 
@@ -326,7 +331,7 @@ MyHome includes MyRoom;
     assertNbAnomalies(report, 1);
     assertAnomaly(report, 0, {
       name: 'redefinedIncludes',
-      message: `The includes statement "MyHome includes MyRoom" is defined more than once in ${specUrl}`
+      message: `The includes statement \`MyHome includes MyRoom\` is defined more than once in ${specUrl}`
     });
   });
 
@@ -337,11 +342,11 @@ MyHome includes MyRoom;
     assertNbAnomalies(report, 2);
     assertAnomaly(report, 0, {
       name: 'unknownType',
-      message: 'Target "MyHome" in includes statement "MyHome includes MyRoom" is not defined anywhere'
+      message: 'Target `MyHome` in includes statement `MyHome includes MyRoom` is not defined anywhere'
     });
     assertAnomaly(report, 1, {
       name: 'unknownType',
-      message: 'Mixin "MyRoom" in includes statement "MyHome includes MyRoom" is not defined anywhere'
+      message: 'Mixin `MyRoom` in includes statement `MyHome includes MyRoom` is not defined anywhere'
     });
   });
 
@@ -355,11 +360,11 @@ MyHome includes MyRoom;
     assertNbAnomalies(report, 2);
     assertAnomaly(report, 0, {
       name: 'wrongKind',
-      message: 'Target "MyHome" in includes statement "MyHome includes MyRoom" must be of kind "interface"'
+      message: 'Target `MyHome` in includes statement `MyHome includes MyRoom` must be of kind `interface`'
     });
     assertAnomaly(report, 1, {
       name: 'wrongKind',
-      message: 'Mixin "MyRoom" in includes statement "MyHome includes MyRoom" must be of kind "interface mixin"'
+      message: 'Mixin `MyRoom` in includes statement `MyHome includes MyRoom` must be of kind `interface mixin`'
     });
   });
 
@@ -373,11 +378,11 @@ dictionary MyShelf : MyHome { required boolean full; };
     assertNbAnomalies(report, 2);
     assertAnomaly(report, 0, {
       name: 'unknownType',
-      message: '"MyLivingRoom" inherits from "MyRoom" which is not defined anywhere'
+      message: '`MyLivingRoom` inherits from `MyRoom` which is not defined anywhere'
     });
     assertAnomaly(report, 1, {
       name: 'wrongKind',
-      message: '"MyShelf" is of kind "dictionary" but inherits from "MyHome" which is of kind "interface"'
+      message: '`MyShelf` is of kind `dictionary` but inherits from `MyHome` which is of kind `interface`'
     });
   });
 
@@ -394,19 +399,19 @@ dictionary MyShelf : MyHome { required boolean full; };
     assertNbAnomalies(report, 4);
     assertAnomaly(report, 0, {
       name: 'unknownType',
-      message: 'Unknown type "bool" used in definition of "MyRoom"'
+      message: 'Unknown type `bool` used in definition of `MyRoom`'
     });
     assertAnomaly(report, 1, {
       name: 'unknownType',
-      message: 'Unknown type "MyBed" used in definition of "MyRoom"'
+      message: 'Unknown type `MyBed` used in definition of `MyRoom`'
     });
     assertAnomaly(report, 2, {
       name: 'unknownType',
-      message: 'Unknown type "MyUnknownType" used in definition of "MyRoom"'
+      message: 'Unknown type `MyUnknownType` used in definition of `MyRoom`'
     });
     assertAnomaly(report, 3, {
       name: 'unknownType',
-      message: 'Unknown type "UnknownInnerType" used in definition of "MyRoom"'
+      message: 'Unknown type `UnknownInnerType` used in definition of `MyRoom`'
     });
   });
 
@@ -426,19 +431,19 @@ interface mixin MyNamespaceMixin {};
     assertNbAnomalies(report, 4);
     assertAnomaly(report, 0, {
       name: 'redefinedWithDifferentTypes',
-      message: `"MyNamespaceMixin" is defined multiple times with different types (namespace, interface mixin) in ${specUrl}`
+      message: `\`MyNamespaceMixin\` is defined multiple times with different types (namespace, interface mixin) in ${specUrl}`
     });
     assertAnomaly(report, 1, {
       name: 'wrongType',
-      message: 'Namespace "MyNamespace" cannot be used as a type in definition of "MyHome"'
+      message: 'Namespace `MyNamespace` cannot be used as a type in definition of `MyHome`'
     });
     assertAnomaly(report, 2, {
       name: 'wrongType',
-      message: 'Interface mixin "MyLivingRoom" cannot be used as a type in definition of "MyHome"'
+      message: 'Interface mixin `MyLivingRoom` cannot be used as a type in definition of `MyHome`'
     });
     assertAnomaly(report, 3, {
       name: 'wrongType',
-      message: 'Name "MyNamespaceMixin" exists but is not a type and cannot be used in definition of "MyHome"'
+      message: 'Name `MyNamespaceMixin` exists but is not a type and cannot be used in definition of `MyHome`'
     });
   });
 
@@ -458,15 +463,15 @@ interface mixin MyNamespaceMixin {};
     assertNbAnomalies(report, 3);
     assertAnomaly(report, 0, {
       name: 'unknownExtAttr',
-      message: 'Unknown extended attribute "UnknownExtAttr" used in definition of "MyRoom"'
+      message: 'Unknown extended attribute `UnknownExtAttr` used in definition of `MyRoom`'
     });
     assertAnomaly(report, 1, {
       name: 'unknownExtAttr',
-      message: 'Unknown extended attribute "SuperUnknownExtAttr" used in definition of "MyLivingRoom"'
+      message: 'Unknown extended attribute `SuperUnknownExtAttr` used in definition of `MyLivingRoom`'
     });
     assertAnomaly(report, 2, {
       name: 'unknownExtAttr',
-      message: 'Unknown extended attribute "SuperUnknownExtAttr" used in definition of "MyBedRoom"'
+      message: 'Unknown extended attribute `SuperUnknownExtAttr` used in definition of `MyBedRoom`'
     });
   });
 
@@ -496,11 +501,11 @@ partial interface MyPartialHome {
     assertNbAnomalies(report, 2);
     assertAnomaly(report, 0, {
       name: 'overloaded',
-      message: '"operation overload" in partial interface "MyHome" overloads an operation defined in interface "MyHome"'
+      message: '`operation overload` in partial interface `MyHome` overloads an operation defined in interface `MyHome`'
     });
     assertAnomaly(report, 1, {
       name: 'overloaded',
-      message: '"operation overload" in partial interface "MyPartialHome" overloads an operation defined in another partial interface "MyPartialHome"'
+      message: '`operation overload` in partial interface `MyPartialHome` overloads an operation defined in another partial interface `MyPartialHome`'
     });
   });
 
@@ -532,7 +537,7 @@ partial interface MyPartialHome {
     assertNbAnomalies(report, 2);
     assertAnomaly(report, 0, {
       name: 'overloaded',
-      message: `"operation overload" in partial interface "MyHome" overloads an operation defined in interface "MyHome" (in ${specUrl})`,
+      message: `\`operation overload\` in partial interface \`MyHome\` overloads an operation defined in interface \`MyHome\` (in ${specUrl})`,
       specs: [{ url: specUrl2 }]
     });
 
@@ -540,7 +545,7 @@ partial interface MyPartialHome {
     // should be reported
     assertAnomaly(report, 1, {
       name: 'overloaded',
-      message: `"operation overload" in partial interface "MyPartialHome" (in ${specUrl2}) overloads an operation defined in another partial interface "MyPartialHome" (in ${specUrl})`,
+      message: `\`operation overload\` in partial interface \`MyPartialHome\` (in ${specUrl2}) overloads an operation defined in another partial interface \`MyPartialHome\` (in ${specUrl})`,
       specs: [{ url: specUrl2 }, { url: specUrl }]
     });
   });
@@ -568,11 +573,11 @@ partial interface mixin MyPartialRoom {
     assertNbAnomalies(report, 2);
     assertAnomaly(report, 0, {
       name: 'overloaded',
-      message: '"operation overload" in interface "MyHome" overloads an operation defined in interface mixin "MyRoom"'
+      message: '`operation overload` in interface `MyHome` overloads an operation defined in interface mixin `MyRoom`'
     });
     assertAnomaly(report, 1, {
       name: 'overloaded',
-      message: '"operation overload" in partial interface mixin "MyPartialRoom" overloads an operation defined in interface mixin "MyPartialRoom"'
+      message: '`operation overload` in partial interface mixin `MyPartialRoom` overloads an operation defined in interface mixin `MyPartialRoom`'
     });
   });
 
@@ -605,25 +610,25 @@ partial interface mixin MyPartialRoom {
     assertNbAnomalies(report, 4);
     assertAnomaly(report, 0, {
       name: 'overloaded',
-      message: `"operation overload" in interface "MyHome" overloads an operation defined in interface mixin "MyRoom" (in ${specUrl2})`,
+      message: `\`operation overload\` in interface \`MyHome\` overloads an operation defined in interface mixin \`MyRoom\` (in ${specUrl2})`,
       specs: [{ url: specUrl }]
     });
 
     assertAnomaly(report, 1, {
       name: 'overloaded',
-      message: '"operation overload" in partial interface mixin "MyPartialRoom" overloads an operation defined in interface mixin "MyPartialRoom"',
+      message: '`operation overload` in partial interface mixin `MyPartialRoom` overloads an operation defined in interface mixin `MyPartialRoom`',
       specs: [{ url: specUrl }]
     });
 
     assertAnomaly(report, 2, {
       name: 'overloaded',
-      message: `"operation overload" in partial interface mixin "MyPartialRoom" overloads an operation defined in interface mixin "MyPartialRoom" (in ${specUrl})`,
+      message: `\`operation overload\` in partial interface mixin \`MyPartialRoom\` overloads an operation defined in interface mixin \`MyPartialRoom\` (in ${specUrl})`,
       specs: [{ url: specUrl2 }]
     });
 
     assertAnomaly(report, 3, {
       name: 'overloaded',
-      message: `"operation overload" in partial interface mixin "MyPartialRoom" (in ${specUrl2}) overloads an operation defined in another partial interface mixin "MyPartialRoom" (in ${specUrl})`,
+      message: `\`operation overload\` in partial interface mixin \`MyPartialRoom\` (in ${specUrl2}) overloads an operation defined in another partial interface mixin \`MyPartialRoom\` (in ${specUrl})`,
       specs: [{ url: specUrl2 }, { url: specUrl }]
     });
   });
@@ -649,15 +654,15 @@ partial interface mixin MyRoom {
     assertNbAnomalies(report, 3);
     assertAnomaly(report, 0, {
       name: 'overloaded',
-      message: '"operation overload" in partial interface "MyHome" overloads an operation defined in interface mixin "MyRoom"'
+      message: '`operation overload` in partial interface `MyHome` overloads an operation defined in interface mixin `MyRoom`'
     });
     assertAnomaly(report, 1, {
       name: 'overloaded',
-      message: '"operation overload" in partial interface "MyHome" overloads an operation defined in partial interface mixin "MyRoom"'
+      message: '`operation overload` in partial interface `MyHome` overloads an operation defined in partial interface mixin `MyRoom`'
     });
     assertAnomaly(report, 2, {
       name: 'overloaded',
-      message: '"operation overload" in partial interface mixin "MyRoom" overloads an operation defined in interface mixin "MyRoom"'
+      message: '`operation overload` in partial interface mixin `MyRoom` overloads an operation defined in interface mixin `MyRoom`'
     });
   });
 
@@ -684,19 +689,19 @@ partial interface mixin MyRoom {
     assertNbAnomalies(report, 3);
     assertAnomaly(report, 0, {
       name: 'overloaded',
-      message: `"operation overload" in partial interface "MyHome" overloads an operation defined in interface mixin "MyRoom" (in ${specUrl2})`,
+      message: `\`operation overload\` in partial interface \`MyHome\` overloads an operation defined in interface mixin \`MyRoom\` (in ${specUrl2})`,
       specs: [{ url: specUrl }]
     });
 
     assertAnomaly(report, 1, {
       name: 'overloaded',
-      message: `"operation overload" in partial interface "MyHome" overloads an operation defined in partial interface mixin "MyRoom" (in ${specUrl2})`,
+      message: `\`operation overload\` in partial interface \`MyHome\` overloads an operation defined in partial interface mixin \`MyRoom\` (in ${specUrl2})`,
       specs: [{ url: specUrl }]
     });
 
     assertAnomaly(report, 2, {
       name: 'overloaded',
-      message: '"operation overload" in partial interface mixin "MyRoom" overloads an operation defined in interface mixin "MyRoom"',
+      message: '`operation overload` in partial interface mixin `MyRoom` overloads an operation defined in interface mixin `MyRoom`',
       specs: [{ url: specUrl2 }]
     });
   });
@@ -721,19 +726,19 @@ interface mixin MyRoom {
     assertNbAnomalies(report, 4);
     assertAnomaly(report, 0, {
       name: 'redefinedMember',
-      message: '"dejaVu" in interface "MyHome" is defined more than once'
+      message: '`dejaVu` in interface `MyHome` is defined more than once'
     });
     assertAnomaly(report, 1, {
       name: 'redefinedMember',
-      message: '"dejaVu" in partial interface "MyHome" duplicates a member defined in interface "MyHome"'
+      message: '`dejaVu` in partial interface `MyHome` duplicates a member defined in interface `MyHome`'
     });
     assertAnomaly(report, 2, {
       name: 'redefinedMember',
-      message: '"dejaVu" in interface "MyHome" duplicates a member defined in interface mixin "MyRoom"'
+      message: '`dejaVu` in interface `MyHome` duplicates a member defined in interface mixin `MyRoom`'
     });
     assertAnomaly(report, 3, {
       name: 'redefinedMember',
-      message: '"dejaVu" in partial interface "MyHome" duplicates a member defined in interface mixin "MyRoom"'
+      message: '`dejaVu` in partial interface `MyHome` duplicates a member defined in interface mixin `MyRoom`'
     });
   });
 
@@ -758,19 +763,19 @@ interface mixin MyRoom {
     assertNbAnomalies(report, 3);
     assertAnomaly(report, 0, {
       name: 'redefinedMember',
-      message: `"dejaVu" in partial interface "MyHome" duplicates a member defined in interface "MyHome" (in ${specUrl})`,
+      message: `\`dejaVu\` in partial interface \`MyHome\` duplicates a member defined in interface \`MyHome\` (in ${specUrl})`,
       specs: [{ url: specUrl2 }]
     });
 
     assertAnomaly(report, 1, {
       name: 'redefinedMember',
-      message: `"dejaVu" in interface "MyHome" duplicates a member defined in interface mixin "MyRoom" (in ${specUrl2})`,
+      message: `\`dejaVu\` in interface \`MyHome\` duplicates a member defined in interface mixin \`MyRoom\` (in ${specUrl2})`,
       specs: [{ url: specUrl }]
     });
 
     assertAnomaly(report, 2, {
       name: 'redefinedMember',
-      message: '"dejaVu" in partial interface "MyHome" duplicates a member defined in interface mixin "MyRoom"',
+      message: '`dejaVu` in partial interface `MyHome` duplicates a member defined in interface mixin `MyRoom`',
       specs: [{ url: specUrl2 }]
     });
   });


### PR DESCRIPTION
Enum values with spaces such as those defined in the `JsonLdErrorCode` enum (https://w3c.github.io/json-ld-api/#dom-jsonlderrorcode) were not reported as anomalies.

IDL anomaly messages were also updated to use backticks, to make them more Markdown-friendly.