### PR TITLE
Adjust --update-mode options

### DIFF
--- a/.github/workflows/file-issue-for-review.yml
+++ b/.github/workflows/file-issue-for-review.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         node strudy.js inspect ../webref \
           --issues issues \
-          --update-mode old \
+          --update-mode untracked \
           --cc ${{ vars.CC }} \
           --what brokenLinks \
           --what discontinuedReferences \


### PR DESCRIPTION
This makes the following changes to the `--update-mode` modes:
- Make "tracked" and "untracked" extend "old"
- Make "tracked" mean "tracked through a GitHub issue. As a corollary, untracked now means "not tracked or tracked with a comment that is not a GitHub URL".

The job now uses the "untracked" mode, meaning it will update reports that we decided not to track when an update is detected.