### PR TITLE
Web IDL study: detect event handlers with no matching event

### DIFF
--- a/src/lib/study.js
+++ b/src/lib/study.js
@@ -151,8 +151,8 @@ const anomalyGroups = [
       { name: 'invalid', title: 'Invalid Web IDL' },
       {
         name: 'noEvent',
-        title: 'Suspicious event handlers',
-        description: 'The following suspicious event handlers were found'
+        title: 'Event handlers with no matching events',
+        description: 'No matching events were found for the following event handlers'
       },
       { name: 'noExposure', title: 'Missing `[Exposed]` attributes' },
       { name: 'noOriginalDefinition', title: 'Missing base interfaces' },

--- a/src/lib/study.js
+++ b/src/lib/study.js
@@ -149,6 +149,11 @@ const anomalyGroups = [
         guidance: 'See the [`[Exposed]`](https://webidl.spec.whatwg.org/#Exposed) extended attribute section in Web IDL for requirements.'
       },
       { name: 'invalid', title: 'Invalid Web IDL' },
+      {
+        name: 'noEvent',
+        title: 'Suspicious event handlers',
+        description: 'The following suspicious event handlers were found'
+      },
       { name: 'noExposure', title: 'Missing `[Exposed]` attributes' },
       { name: 'noOriginalDefinition', title: 'Missing base interfaces' },
       { name: 'overloaded', title: 'Invalid overloaded operations' },

--- a/test/study-webidl.js
+++ b/test/study-webidl.js
@@ -148,7 +148,7 @@ interface WhereIAm {};
     });
   });
 
-  it('reports no anomaly for valid EventHandler attributes definitions', () => {
+  it('reports EventHandler attributes with no matching events', () => {
     const report = analyzeIdl(`
 [Exposed=*]
 interface Event {};
@@ -163,6 +163,34 @@ interface Carlos : EventTarget {
 [Exposed=*]
 interface EventTarget {};
 `);
+    assertNbAnomalies(report, 1);
+    assertAnomaly(report, 0, {
+      name: 'noEvent',
+      message: 'The interface `Carlos` defines an event handler `onbigbisous` but no event named "bigbisous" targets it'
+    });
+  });
+
+  it('reports no anomaly for valid EventHandler attributes definitions', () => {
+    const crawlResult = toCrawlResult(`
+[Exposed=*]
+interface Event {};
+[LegacyTreatNonObjectAsNull]
+callback EventHandlerNonNull = any (Event event);
+typedef EventHandlerNonNull? EventHandler;
+
+[Global=Window,Exposed=*]
+interface Carlos : EventTarget {
+  attribute EventHandler onbigbisous;
+};
+[Exposed=*]
+interface EventTarget {};
+`);
+    crawlResult[0].events = [{
+      type: 'bigbisous',
+      interface: 'Event',
+      targets: ['Carlos']
+    }];
+    const report = study(crawlResult);
     assertNbAnomalies(report, 0);
   });
 
@@ -179,11 +207,73 @@ interface Carlos {
   attribute EventHandler onbigbisous;
 };
 `);
-    assertNbAnomalies(report, 1);
+    assertNbAnomalies(report, 2);
     assertAnomaly(report, 0, {
       name: 'unexpectedEventHandler',
       message: 'The interface `Carlos` defines an event handler `onbigbisous` but does not inherit from `EventTarget`'
     });
+    assertAnomaly(report, 1, { name: 'noEvent' });
+  });
+
+  it('follows the inheritance chain to assess event targets', () => {
+    const crawlResult = toCrawlResult(`
+[Exposed=*]
+interface Event {};
+[LegacyTreatNonObjectAsNull]
+callback EventHandlerNonNull = any (Event event);
+typedef EventHandlerNonNull? EventHandler;
+
+[Global=Window,Exposed=*]
+interface Singer : EventTarget {
+  attribute EventHandler onbigbisous;
+};
+
+[Global=Window,Exposed=*]
+interface Carlos : Singer {};
+[Exposed=*]
+interface EventTarget {};
+`);
+    crawlResult[0].events = [{
+      type: 'bigbisous',
+      interface: 'Event',
+      targets: [
+        'Carlos'
+      ]
+    }];
+    const report = study(crawlResult);
+    assertNbAnomalies(report, 0);
+  });
+
+  it('follows the bubbling path to assess event targets', () => {
+    const crawlResult = toCrawlResult(`
+[Exposed=*]
+interface Event {};
+[LegacyTreatNonObjectAsNull]
+callback EventHandlerNonNull = any (Event event);
+typedef EventHandlerNonNull? EventHandler;
+
+[Global=Window,Exposed=*]
+interface IDBDatabase : EventTarget {
+  attribute EventHandler onabort;
+};
+[Global=Window,Exposed=*]
+interface IDBTransaction : EventTarget {
+  attribute EventHandler onabort;
+};
+[Global=Window,Exposed=*]
+interface MyIndexedDB : IDBDatabase {
+};
+
+[Exposed=*]
+interface EventTarget {};`);
+    crawlResult[0].events = [{
+      type: 'abort',
+      interface: 'Event',
+      targets: ['IDBTransaction'],
+      bubbles: true
+    }];
+    const report = study(crawlResult);
+    assertNbAnomalies(report, 0);
   });
 
   it('detects incompatible partial exposure issues', () => {


### PR DESCRIPTION
As discussed in https://github.com/w3c/webref/issues/1216, when an interface defines an event handler, there should always be an event named after the event handler that targets the interface. The new `noEvent` anomaly detects situations where the event is missing.

The analysis reports the two anomalies mentioned in https://github.com/w3c/webref/issues/1216#issuecomment-2068997553

(The analysis reports additional anomalies when run on the raw extracts. That's normal and due to missing event targets that get added during curation)

I do not know yet to what extent we want to make that a guarantee for the Webref events package. First exception-to-the rule is easy to explain. The second one for `RTCIceTransport.onerror` will hopefully be fixed at some point, the overall question being: what patching do we do when we bump into a problem that does not get fixed immediately?