### PR TITLE
Run IDL analyses on curated branch, enable noEvent

### DIFF
--- a/.github/workflows/file-issue-for-review.yml
+++ b/.github/workflows/file-issue-for-review.yml
@@ -28,7 +28,7 @@ jobs:
         git config user.email "<>"
         git remote set-url --push origin https://x-access-token:${{ secrets.ISSUE_REPORT_GH_TOKEN }}@github.com/$GITHUB_REPOSITORY
       working-directory: strudy
-    - name: Run Strudy to detect new anomalies
+    - name: Analyze the raw crawl results
       working-directory: strudy
       run: |
         node strudy.js inspect ../webref \
@@ -37,10 +37,24 @@ jobs:
           --cc ${{ vars.CC }} \
           --what brokenLinks \
           --what discontinuedReferences \
+          --what missingTask
+    - name: Switch to the curated branch
+      working-directory: webref
+      # Note: final "--" makes it clear that we're talking about the branch
+      # and not the folder. The "curated" folder should not exist in a job
+      # context, but better err on the safe side!
+      run: git checkout curated --
+    - name: Analyze the curated crawl results
+      working-directory: strudy
+      run: |
+        node strudy.js inspect ../webref \
+          --issues issues \
+          --update-mode untracked \
+          --cc ${{ vars.CC }} \
           --what incompatiblePartialIdlExposure \
           --what unexpectedEventHandler \
           --what wrongCaseEnumValue \
-          --what missingTask
+          --what noEvent
     - name: Run issue filer script
       working-directory: strudy
       run: node src/reporting/file-issue-for-review.js --max 10


### PR DESCRIPTION
This duplicates the calls to Strudy in the analysis job: first pass analyzes the raw crawl results, second pass runs further analyses (not the same ones!) on the curated crawl results. IDL analyses are now done as part of the second pass.

The rationale is that some IDL anomalies may be indirectly triggered by another IDL hiccup that we already identified and reported while doing data curation in Webref. This makes it at least theoretically possible to end up in a situation where we detect an anomaly twice (from two different angles). It seems better to run further IDL analyses on the curated branch instead.

This is particularly needed for the new `noEvent` anomaly, which would otherwise report problems that our events patching already takes care of.

The `noEvent` anomaly will create two issues next time the job runs:
- one for `HTMLBodyElement.onorientationchange`, already covered in the spec: https://compat.spec.whatwg.org/#windoworientation-interface
- one for `RTCIceTransport.onerror`, already tracked in: https://github.com/w3c/webrtc-ice/issues/47