### PR TITLE
Checkout curated branch for curated-based job

### DIFF
--- a/.github/workflows/file-issue-for-review.yml
+++ b/.github/workflows/file-issue-for-review.yml
@@ -57,11 +57,11 @@ jobs:
           --cc ${{ vars.CC }} \
           --what missingTask
     - name: Switch to the curated branch
-      working-directory: webref
-      # Note: final "--" makes it clear that we're talking about the branch
-      # and not the folder. The "curated" folder should not exist in a job
-      # context, but better err on the safe side!
-      run: git checkout curated --
+      uses: actions/checkout@v4
+      with:
+        repository: w3c/webref
+        path: webref
+        ref: curated
     - name: Analyze the curated crawl results
       working-directory: strudy
       if: ${{ inputs.profile == 'regular' }}


### PR DESCRIPTION
I think action/checkout only fetches the main branch, so re-using it to fetch the curated branch feels like the cleanest approach.