### PR TITLE
Add `requirements.txt` to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "files": [
     "index.js",
     "strudy.js",
-    "src/"
+    "src/",
+    "requirements.txt"
   ],
   "bugs": {
     "url": "https://github.com/w3c/strudy/issues"


### PR DESCRIPTION
The file is not included by default, but needed by `studyCddl` to retrieve the version of the CDDL parser to use.