### PR TITLE
Relax "queue a task" regexp for custom tasks

### DIFF
--- a/src/lib/study-algorithms.js
+++ b/src/lib/study-algorithms.js
@@ -76,7 +76,7 @@ function studyAlgorithms(specs) {
   function findAnomalyInParallelStep(spec, algo, step) {
     if (step.html) {
       const html = normalize(step.html);
-      if (html.match(/queu(e|ing) an?( \w+){0,2} (micro)?task/i)) {
+      if (html.match(/queu(e|ing) an?( \w+){0,3} (micro)?task/i)) {
         return false;
       }
       if (html.match(/(^|>| )(resolve|reject)(<| )/i) &&

--- a/test/study-algorithms.js
+++ b/test/study-algorithms.js
@@ -34,4 +34,23 @@ describe('The algorithms analyser', () => {
       spec: { url: 'https://www.w3.org/TR/spec' }
     });
   });
+
+  it('reports no anomaly when a step queues a custom task', () => {
+    const crawlResult = toCrawlResult([
+      {
+        html: 'The custom() method MUST run the following steps:',
+        rationale: 'if',
+        steps: [
+          { html: 'Let <var>p</var> be a new promise.' },
+          { html: 'In parallel',
+            steps: [
+              { html: 'Queue a custom but fantastic task to resolve <var>p</var> with undefined' }
+            ]
+          }
+        ]
+      }
+    ]);
+    const report = study(crawlResult);
+    assertNbAnomalies(report, 0);
+  });
 });


### PR DESCRIPTION
The regular expression used to detect "queue a [custom] task" only accounted for cases where "[custom]" contained at most 2 words. This update relaxes the regular expression to account for situations where it contains 3 words, as happens in the Handwriting Recognition API.

The regular expression remains somewhat strict on purpose not to match on too many things for now. We may need to relax it later on, I just propose to adjust it as we learn from experience.