### PR TITLE
Remove 'challenging' profile of issue filer

### DIFF
--- a/.github/workflows/file-issue-for-review.yml
+++ b/.github/workflows/file-issue-for-review.yml
@@ -8,7 +8,7 @@ on:
         type: choice
         options:
           - regular
-          - challenging
+#          - challenging
 
 name: Submit draft issue reports from Strudy analysis
 jobs:
@@ -47,15 +47,15 @@ jobs:
           --cc ${{ vars.CC }} \
           --what brokenLinks \
           --what discontinuedReferences \
-    - name: Analyze the raw crawl results (challenging)
-      working-directory: strudy
-      if: ${{ inputs.profile == 'challenging' }}
-      run: |
-        node strudy.js inspect ../webref \
-          --issues issues \
-          --update-mode untracked \
-          --cc ${{ vars.CC }} \
           --what missingTask
+#    - name: Analyze the raw crawl results (challenging)
+#      working-directory: strudy
+#      if: ${{ inputs.profile == 'challenging' }}
+#      run: |
+#        node strudy.js inspect ../webref \
+#          --issues issues \
+#          --update-mode untracked \
+#          --cc ${{ vars.CC }} \
     - name: Switch to the curated branch
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
The list of 'challenging' issues has been drained now, and can be handled as part of the regular pipe.

Kept the code in comments to ease re-enabling it if/when we add new similar tests.