### PR TITLE
Add initial CSS anomalies tests

### DIFF
--- a/src/lib/study-css.js
+++ b/src/lib/study-css.js
@@ -72,7 +72,7 @@ export default function studyCSS(specs, { crawlResults = null } = {}) {
     if (actualDfns.length === 0) {
       // No base definition found? Let's report if extensions are defined.
       // Otherwise, that just means we don't have a value for the base
-      // definition. That's find, we'll just assume the first dfn that is
+      // definition. That's fine, we'll just assume the first dfn that is
       // not an extension is the base definition
       for (const dfn of dfns) {
         if (dfn.newValues) {

--- a/src/lib/study-css.js
+++ b/src/lib/study-css.js
@@ -1,0 +1,172 @@
+/**
+ * The CSS checker analyzes CSS extracts and reports on constructs that look
+ * suspicious:
+ * - constructs defined as "type" whereas they seem to be a "function", such as
+ * `<foo()>`
+ * - constructs re-defined in specs that do not belong to the same series
+ * - constructs that exist both as scoped (for another property) and unscoped,
+ * when the underlying syntax is different.
+ *
+ * @module checker
+ */
+
+/**
+ * High-level categories of CSS features that the CSS extracts contain
+ */
+const categories = [
+  'atRules',
+  'properties',
+  'selectors',
+  'values'
+];
+
+const specName = spec => spec.shortname ?? spec.url;
+
+/**
+ * Checks the CSS extracts
+ *
+ * @function
+ * @public
+ */
+export default function studyCSS(specs, { crawlResults = null } = {}) {
+  const res = [];
+
+  // We need to consider all CSS definitions, even if caller is only interested
+  // in a few specific specs.
+  const allSpecs = ((crawlResults?.length > 0) ? crawlResults : specs)
+    .filter(spec => spec.css);
+
+  // Merge features into a single namespace.
+  // Note: names in different categories follow different naming conventions,
+  // and don't collide in practice.
+  const features = {};
+  for (const spec of allSpecs) {
+    for (const category of categories) {
+      for (const feature of spec.css[category] ?? []) {
+        let featureName = '`' + feature.name + '`';
+        if (!features[featureName]) {
+          features[featureName] = [];
+        }
+        features[featureName].push(Object.assign({ spec }, feature));
+
+        // Also add scoped functions and types definitions
+        for (const value of feature.values ?? []) {
+          if (value.type === 'function' || value.type === 'type') {
+            featureName = '`' + value.name + '` for `' + feature.name + '`';
+            if (!features[featureName]) {
+              features[featureName] = [];
+            }
+            features[featureName].push(Object.assign(
+              { spec, for: feature.name },
+              value));
+          }
+        }
+      }
+    }
+  }
+
+  // Analyze the merged list of features
+  for (const [name, dfns] of Object.entries(features)) {
+    // Filter out definitions that extend a base definition
+    let actualDfns = dfns.filter(dfn => dfn.value);
+    if (actualDfns.length === 0) {
+      // No base definition found? Let's report if extensions are defined.
+      // Otherwise, that just means we don't have a value for the base
+      // definition. That's find, we'll just assume the first dfn that is
+      // not an extension is the base definition
+      for (const dfn of dfns) {
+        if (dfn.newValues) {
+          res.push({
+            name: 'cssMissingBaseDfn',
+            message: `${name} is extended in ${specName(dfn.spec)}, but base definition was not found`,
+            spec: dfn.spec
+          });
+        }
+      }
+      actualDfns = dfns.filter(dfn => !dfn.newValues);
+    }
+    for (const dfn of actualDfns) {
+      if (!dfn.href) {
+        res.push({
+          name: 'cssMissingHref',
+          message: name,
+          spec: dfn.spec
+        });
+      }
+    }
+
+    // Look for redefinitions in different spec series
+    const series = {};
+    for (const dfn of actualDfns) {
+      // Note: crawls have series information for all specs, tests may not
+      const seriesShortname = dfn.spec?.series?.shortname;
+      if (seriesShortname) {
+        if (!series[seriesShortname]) {
+          series[seriesShortname] = [];
+        }
+        series[seriesShortname].push(dfn.spec);
+      }
+    }
+    if (Object.keys(series).length > 1) {
+      const specs = Object.values(series).flat();
+      res.push({
+        name: 'cssRedefined',
+        message: name + ' gets redefined in different spec series, found definitions in ' + specs.map(specName).join(', '),
+        specs
+      });
+    }
+
+    // Check scoped definitions don't also have an unscoped definition.
+    const reScoped = /^(.*) for .*/;
+    if (name.match(reScoped)) {
+      const unscopedName = name.replace(reScoped, '$1');
+      const unscoped = features[unscopedName];
+      if (unscoped) {
+        // Note we're going to take the first value definition
+        // (in raw extracts, there may be duplicates, but these will be
+        // reported as anomalies in any case)
+        const actualScoped = dfns.find(dfn => dfn.value);
+        const actualUnscoped = unscoped.find(dfn => dfn.value);
+        if (actualScoped?.value !== actualUnscoped?.value) {
+          res.push({
+            name: 'cssScoped',
+            message: `${name} is also defined without scoping in ${specName(actualUnscoped?.spec ?? unscoped[0].spec)}, syntaxes differ`,
+            spec: actualScoped?.spec ?? dfns[0].spec
+          });
+        }
+        else {
+          res.push({
+            name: 'cssScoped',
+            message: `${name} is also defined without scoping in ${specName(actualUnscoped?.spec ?? unscoped[0].spec)}, same syntax`,
+            spec: actualUnscoped?.spec ?? unscoped[0].spec
+          });
+        }
+      }
+    }
+  }
+
+  // Check that features that look like types are correctly defined as such,
+  // and same thing for functions.
+  for (const spec of specs) {
+    if (!spec.css) {
+      continue;
+    }
+    for (const feature of spec.css.values ?? []) {
+      if (feature.type === 'type' && feature.name.match(/^<.*\(\)>$/)) {
+        res.push({
+          name: 'cssTypeMismatch',
+          message: '`' + feature.name + '` is defined as `type` instead of `function`',
+          spec
+        });
+      }
+      else if (feature.type === 'function' && !feature.name.match(/^.*\(\)$/)) {
+        res.push({
+          name: 'cssTypeMismatch',
+          message: '`' + feature.name + '` is defined as `function` instead of `type`',
+          spec
+        });
+      }
+    }
+  } 
+  return res;
+}

--- a/src/lib/study-css.js
+++ b/src/lib/study-css.js
@@ -33,7 +33,7 @@ export default function studyCSS(specs, { crawlResults = null } = {}) {
 
   // We need to consider all CSS definitions, even if caller is only interested
   // in a few specific specs.
-  const allSpecs = ((crawlResults?.length > 0) ? crawlResults : specs)
+  const allSpecs = (crawlResults?.length ? crawlResults : specs)
     .filter(spec => spec.css);
 
   // Merge features into a single namespace.

--- a/src/lib/study.js
+++ b/src/lib/study.js
@@ -1,4 +1,5 @@
 import studyCddl from './study-cddl.js';
+import studyCSS from './study-css.js';
 import studyDfns from './study-dfns.js';
 import studyAlgorithms from './study-algorithms.js';
 import studyBackrefs from './study-backrefs.js';
@@ -201,6 +202,40 @@ const anomalyGroups = [
       }
     ],
     study: studyCddl
+  },
+
+  {
+    name: 'css',
+    title: 'Problems with CSS constructs',
+    description: 'The following problems were identified when analyzing CSS extracts',
+    types: [
+      {
+        name: 'cssTypeMismatch',
+        title: 'Type mismatch',
+        description: 'The following constructs were found with an unexpected type'
+      },
+      {
+        name: 'cssRedefined',
+        title: 'Redefined in unrelated specs',
+        description: 'The following constructs were found more than once in unrelated specs'
+      },
+      {
+        name: 'cssScoped',
+        title: 'Scoped and unscoped',
+        description: 'The following scoped constructs were found to also have an unscoped definition'
+      },
+      {
+        name: 'cssMissingBaseDfn',
+        title: 'Missing base definitions',
+        description: 'The following extended definitions were found while no base definition seems to exist'
+      },
+      {
+        name: 'cssMissingHref',
+        title: 'Missing link back to spec',
+        description: 'The following base definitions were found without a link back to the spec'
+      }
+    ],
+    study: studyCSS
   }
 ];
 

--- a/test/study-css.js
+++ b/test/study-css.js
@@ -1,0 +1,198 @@
+import { describe, it } from 'node:test';
+import studyCSS from '../src/lib/study-css.js';
+import { assertNbAnomalies, assertAnomaly } from './util.js';
+
+const specUrl = 'https://www.w3.org/TR/spec';
+const specUrl2 = 'https://www.w3.org/TR/spec2';
+
+describe('The CSS analyser', () => {
+  it('reports types that look like functions', async () => {
+    const crawlResults = [
+      {
+        url: specUrl,
+        css: {
+          values: [
+            {
+              name: '<foo()>',
+              type: 'type',
+              href: specUrl + '#foo'
+            }
+          ]
+        }
+      }
+    ];
+    const report = await studyCSS(crawlResults);
+    assertNbAnomalies(report, 1);
+    assertAnomaly(report, 0, {
+      name: 'cssTypeMismatch',
+      message: '`<foo()>` is defined as `type` instead of `function`',
+      spec: { url: specUrl }
+    });
+  });
+
+  it('reports functions that look like types', async () => {
+    const crawlResults = [
+      {
+        url: specUrl,
+        css: {
+          values: [
+            {
+              name: 'foo',
+              type: 'function',
+              href: specUrl + '#foo'
+            }
+          ]
+        }
+      }
+    ];
+    const report = await studyCSS(crawlResults);
+    assertNbAnomalies(report, 1);
+    assertAnomaly(report, 0, {
+      name: 'cssTypeMismatch',
+      message: '`foo` is defined as `function` instead of `type`',
+      spec: { url: specUrl }
+    });
+  });
+
+  it('reports multiple definitions in unrelated specs', async () => {
+    const css = {
+      values: [
+        {
+          name: 'foo()',
+          type: 'function',
+          href: specUrl + '#foo'
+        }
+      ]
+    };
+    const crawlResults = [
+      {
+        url: specUrl,
+        shortname: 'spec1',
+        series: {
+          shortname: 'series1'
+        },
+        css
+      },
+      {
+        url: specUrl2,
+        shortname: 'spec2',
+        series: {
+          shortname: 'series2'
+        },
+        css
+      }
+    ];
+    
+    const report = await studyCSS(crawlResults);
+    assertNbAnomalies(report, 1);
+    assertAnomaly(report, 0, {
+      name: 'cssRedefined',
+      message: '`foo()` gets redefined in different spec series, found definitions in spec1, spec2',
+      specs: crawlResults
+    });
+  });
+
+  it('reports about scoped vs. unscoped', async () => {
+    const crawlResults = [
+      {
+        url: specUrl,
+        css: {
+          properties: [
+            {
+              name: 'prop',
+              href: specUrl + '#prop',
+              values: [
+                {
+                  name: 'foo()',
+                  type: 'function',
+                  href: specUrl + '#prop-foo'
+                },
+                {
+                  name: 'bar()',
+                  type: 'function',
+                  value: 'bar(bu)',
+                  href: specUrl + '#prop-bar'
+                }
+              ]
+            }
+          ],
+          values: [
+            {
+              name: 'foo()',
+              type: 'function',
+              href: specUrl + '#foo'
+            },
+            {
+              name: 'bar()',
+              type: 'function',
+              value: 'bar(bant)',
+              href: specUrl + '#bar'
+            }
+          ]
+        }
+      }
+    ];
+    const report = await studyCSS(crawlResults);
+    assertNbAnomalies(report, 2);
+    assertAnomaly(report, 0, {
+      name: 'cssScoped',
+      message: '`foo()` for `prop` is also defined without scoping in https://www.w3.org/TR/spec, same syntax',
+      spec: { url: specUrl }
+    });
+    assertAnomaly(report, 1, {
+      name: 'cssScoped',
+      message: '`bar()` for `prop` is also defined without scoping in https://www.w3.org/TR/spec, syntaxes differ',
+      spec: { url: specUrl }
+    });
+  });
+
+  it('reports extensions without base definitions', async () => {
+    const css = {
+      properties: [
+        {
+          name: 'foo',
+          newValues: 'bar',
+          href: specUrl + '#foo'
+        }
+      ]
+    };
+    const crawlResults = [
+      {
+        url: specUrl,
+        shortname: 'spec1',
+        css
+      }
+    ];
+
+    const report = await studyCSS(crawlResults);
+    assertNbAnomalies(report, 1);
+    assertAnomaly(report, 0, {
+      name: 'cssMissingBaseDfn',
+      message: '`foo` is extended in spec1, but base definition was not found',
+      spec: { url: specUrl }
+    });
+  });
+
+  it('reports missing links back to the spec', async () => {
+    const crawlResults = [
+      {
+        url: specUrl,
+        css: {
+          values: [
+            {
+              name: 'foo()',
+              type: 'function'
+            }
+          ]
+        }
+      }
+    ];
+    const report = await studyCSS(crawlResults);
+    assertNbAnomalies(report, 1);
+    assertAnomaly(report, 0, {
+      name: 'cssMissingHref',
+      message: '`foo()`',
+      spec: { url: specUrl }
+    });
+  });
+});


### PR DESCRIPTION
This creates a new module that checks CSS extracts. New anomalies reported when:

1. A CSS construct that looks like a type (resp. function) is defined as a function (resp. type), e.g., if `foo()` is defined as `type`. That should not happen much. Last anomalies of this type were fixed recently in css-values-5.
2. A CSS construct gets redefined in unrelated specs. CSS properties were already checked in Webref. This extends the check to all types of constructs. This reports a number of duplicates when run against raw crawl results. That's normal, duplicates are handled through curation. Two additional type dfns get reported in css-color-5 and css-color-hdr. Some patch will be needed to address them.
3. A CSS construct is extended in a spec, but no base definition seems to exist. This was already checked by Webref. No problems detected for now.
4. A CSS definition was found without any link back to the actual definition in the spec. This was also already checked by Webref. No problems detected for now.
5. A CSS construct with a definition scoped to another construct also has an unscoped definition. About 10 occurrences today but some of them are due to the unscoped dfn appearing in a spec that has not yet been published to /TR, so I would recommend ignoring them for now.

Goal is to update the tests in Webref to rather use Strudy and extend the guarantees accordingly (excluding 5 above initially).