### PR TITLE
Adjust hardcoded code for Push API algorithm

### DIFF
--- a/src/lib/study-algorithms.js
+++ b/src/lib/study-algorithms.js
@@ -82,7 +82,8 @@ function studyAlgorithms(specs) {
       if (html.match(/(^|>| )(resolve|reject)(<| )/i) &&
           // Push API checks on the status of promises:
           // https://w3c.github.io/push-api/#receiving-a-push-message
-          !html.match(/(wait for|if) all( of)? the promises/i) &&
+          !html.match(/wait for all of the promises/i) &&
+          !html.match(/>notificationResult</) &&
           // Clipboard APIs uses "resolve" to mean something else:
           // https://w3c.github.io/clipboard-apis/#dom-clipboard-read
           !html.includes('systemClipboardRepresentation')

--- a/test/study-algorithms.js
+++ b/test/study-algorithms.js
@@ -54,4 +54,20 @@ describe('The algorithms analyser', () => {
     const report = study(crawlResult);
     assertNbAnomalies(report, 0);
   });
+
+  it('reports no anomaly for the push API', () => {
+    const crawlResult = toCrawlResult([
+      {
+        html: 'Then run the following steps in parallel, with <var>dispatchedEvent</var>:',
+        rationale: 'wait',
+        steps: [
+          { html: '<p>Wait for all of the promises in the <a data-link-type=\"dfn\" data-link-for=\"ExtendableEvent\" data-xref-for=\"ExtendableEvent\" data-cite=\"service-workers\" data-cite-path=\"\" data-cite-frag=\"extendableevent-extend-lifetime-promises\" href=\"https://www.w3.org/TR/service-workers/#extendableevent-extend-lifetime-promises\">extend lifetime promises</a> of <var>dispatchedEvent</var> to resolve.</p>' },
+          { html: '<p>If they do not resolve successfully, then set <var>notificationResult</var> to something.</p>' },
+          { html: '<p>Otherwise, do something else.</p>' }
+        ]
+      }
+    ]);
+    const report = study(crawlResult);
+    assertNbAnomalies(report, 0);
+  });
 });


### PR DESCRIPTION
Via https://github.com/w3c/strudy/pull/1040

The former regular expression did not catch the new sentence: "If they do not resolve successfully, then set notificationResult to failure."

The update makes the code avoid steps that contain a `notificationResult` variable (name is only used in the Push API).