### PR TITLE
Drop auto-assignments of cleanup PRs

### DIFF
--- a/.github/workflows/clean-reports.yml
+++ b/.github/workflows/clean-reports.yml
@@ -42,6 +42,5 @@ jobs:
         commit-message: "Drop no longer relevant reports"
         body: ${{ env.dropped_reports }}
         path: strudy
-        assignees: tidoust, dontcallmedom
         branch: clean-reports
         branch-suffix: timestamp


### PR DESCRIPTION
Assigning the PRs has not proved useful or needed to force us to look into the PRs, and forces to maintain a list of assignees somewhere for no good reason.

FYI, @dontcallmedom, I also removed your name from the `CC` repo variable so that you no longer appear in proposed anomaly issues from now on.