### PR TITLE
Consider legacy window alias interface names as valid IDL types

### DIFF
--- a/src/lib/study-webidl.js
+++ b/src/lib/study-webidl.js
@@ -509,6 +509,25 @@ function studyWebIdl (specs, { crawledResults = [], curatedResults = [] } = {}) 
             }
           }
           parseIdlNode(dfn, spec);
+
+          // A handful of interfaces define legacy aliases that should count as
+          // known IDL types. They are used to create standalone SVG interfaces
+          // for a few DOM* interfaces defined in the Geometry spec, to account
+          // for the fact that implementations continue to use SVG* interfaces
+          // in practice, see context in:
+          // https://github.com/w3c/svgwg/pull/1143
+          const legacyAliasesEA = dfn.extAttrs?.find(ea => ea.name === 'LegacyWindowAlias');
+          if (legacyAliasesEA) {
+            const legacyAliases = Array.isArray(legacyAliasesEA.rhs.value) ?
+              legacyAliasesEA.rhs.value.map(({ value }) => value) :
+              [legacyAliasesEA.rhs.value];
+            for (const legacyAlias of legacyAliases) {
+              if (!dfns[legacyAlias]) {
+                dfns[legacyAlias] = [];
+              }
+              dfns[legacyAlias].push({ spec, idl: dfn });
+            }
+          }
         } else if (dfn.type === 'includes') {
           // Includes statement:
           // https://webidl.spec.whatwg.org/#index-prod-IncludesStatement

--- a/test/study-webidl.js
+++ b/test/study-webidl.js
@@ -473,6 +473,22 @@ dictionary MyShelf : MyHome { required boolean full; };
     });
   });
 
+  it('considers types defined through LegacyWindowAlias', () => {
+    const report = analyzeIdl(`
+[Exposed=*,
+ LegacyWindowAlias=(SVGMatrix,WebKitCSSMatrix)]
+interface DOMMatrix {
+    constructor();
+};
+
+[Exposed=*]
+interface SVGGraphicsElement {
+  SVGMatrix? getCTM();
+};
+`);
+    assertNbAnomalies(report, 0);
+  });
+
   it('reports wrong types', () => {
     const report = analyzeIdl(`
 [Global=Home,Exposed=*] interface MyHome {


### PR DESCRIPTION
SVG used to define `SVGRect`, `SVGMatrix`, and `SVGPoint` interfaces. These interfaces now exist as `DOMRect`, `DOMMatrix`, and `DOMPoint` in the Geometry Interfaces spec and the SVG spec had been updated to use the newer interface names as a result, with the expectation that SVG implementations would catch up.

Implementations never caught up and continue to use the `SVG*` interfaces. To reflect reality, the SVG spec was thus updated to roll back to reuse `SVGRect`, `SVGMatrix`, and `SVGPoint`. These names appear in the definitions of the `DOM*` interfaces as `LegacyWindowAlias`.

Strudy reported the `SVG*` interfaces as unknown IDL types because it ignored the `LegacyWindowAlias` names. This update makes Strudy also add the names defined in `LegacyWindowAlias` extended attributes as valid IDL types.