### PR TITLE
Add algo exceptions for Digital Credentials and Screen orientations

### DIFF
--- a/src/lib/study-algorithms.js
+++ b/src/lib/study-algorithms.js
@@ -86,7 +86,13 @@ function studyAlgorithms(specs) {
           !html.match(/>notificationResult</) &&
           // Clipboard APIs uses "resolve" to mean something else:
           // https://w3c.github.io/clipboard-apis/#dom-clipboard-read
-          !html.includes('systemClipboardRepresentation')
+          !html.includes('systemClipboardRepresentation') &&
+          // Digital Credentials has a custom "reject" algo that queues a task
+          // https://w3c-fedid.github.io/digital-credentials/#dfn-reject-the-credential-request-with
+          !html.match(/reject the credential request with/i) &&
+          // Screen orientation has a custom "reject" algo that queues a task
+          // https://w3c.github.io/screen-orientation/#dfn-reject-and-nullify-the-current-lock-promise
+          !html.match(/reject and nullify the current lock promise/i)
       ) {
         report.push({
           name: 'missingTask',

--- a/test/study-algorithms.js
+++ b/test/study-algorithms.js
@@ -70,4 +70,32 @@ describe('The algorithms analyser', () => {
     const report = study(crawlResult);
     assertNbAnomalies(report, 0);
   });
+
+  it('reports no anomaly when "reject a credential request" is used', () => {
+    const crawlResult = toCrawlResult([
+      {
+        html: 'In parallel:',
+        rationale: 'wait',
+        steps: [
+          { html: '<p>Reject the credential request with <var>error</var> and <var data-type="Promise">promise</var>.</p>' },
+        ]
+      }
+    ]);
+    const report = study(crawlResult);
+    assertNbAnomalies(report, 0);
+  });
+
+  it('reports no anomaly when "reject and nullify the current lock promise" is used', () => {
+    const crawlResult = toCrawlResult([
+      {
+        html: 'In parallel:',
+        rationale: 'wait',
+        steps: [
+          { html: '<p>Reject and nullify the current lock promise of document with an <code>AbortError</code>.</p>' },
+        ]
+      }
+    ]);
+    const report = study(crawlResult);
+    assertNbAnomalies(report, 0);
+  });
 });


### PR DESCRIPTION
Via https://github.com/w3c/strudy/pull/1279 and https://github.com/w3c/strudy/pull/253. The Digital Credentials spec defines a specific algorithm named "Reject the credential request with" that queues a global task, and can safely be called from steps that run in parallel.

Similarly, the Screen Orientation spec defines a specific algorithm named "Reject and nullify the current lock promise" that also queues a global task.

Having to hardcode these as exceptions is not fantastic, but the list seems to grow slowly for now. A better (but much more involved) approach would be to make the code understand what it's parsing...