### PR TITLE
Allow Puppeteer's post-install script by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   },
   "scripts": {
     "test": "node --test --test-reporter=spec"
+  },
+  "allowScripts": {
+    "puppeteer": true
   }
 }


### PR DESCRIPTION
Npm now defaults to blocking post-install scripts of dependencies. This adds Puppeteer (any version) to the allow-list as described in: https://pptr.dev/troubleshooting#blocked-install-scripts