### PR TITLE
Setup Node.js after checkout in workflows

### DIFF
--- a/.github/workflows/clean-pending-reports.yml
+++ b/.github/workflows/clean-pending-reports.yml
@@ -8,12 +8,12 @@ jobs:
   clean:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout strudy
+      uses: actions/checkout@v7
     - name: Setup node.js
       uses: actions/setup-node@v7
       with:
         node-version-file: .node-version
-    - name: Checkout strudy
-      uses: actions/checkout@v7
     - name: Install dependencies
       run: |
         npm ci

--- a/.github/workflows/clean-reports.yml
+++ b/.github/workflows/clean-reports.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v7
       with:
-        node-version-file: .node-version
+        node-version-file: strudy/.node-version
 
     - name: Install dependencies
       working-directory: strudy

--- a/.github/workflows/file-issue-for-review.yml
+++ b/.github/workflows/file-issue-for-review.yml
@@ -15,14 +15,14 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-    - name: Setup node.js
-      uses: actions/setup-node@v7
-      with:
-        node-version-file: .node-version
     - name: Checkout strudy
       uses: actions/checkout@v7
       with:
         path: strudy
+    - name: Setup node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version-file: strudy/.node-version
     - name: Install dependencies
       run: npm ci
       working-directory: strudy

--- a/.github/workflows/submit-issue.yml
+++ b/.github/workflows/submit-issue.yml
@@ -6,12 +6,12 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout strudy
+      uses: actions/checkout@v7
     - name: Setup node.js
       uses: actions/setup-node@v7
       with:
         node-version-file: .node-version
-    - name: Checkout strudy
-      uses: actions/checkout@v7
     - name: Install dependencies
       run: npm ci
     - name: Configure git


### PR DESCRIPTION
Relying on a `.node-version` file to specify the version of Node.js to use across workflows is fine, but that file needs to exist before it can be used. Typically, this means that the checkout action needs to run *before* the setup-node action (and the path to the file needs to be the right one).

This update swaps the order of the actions and adjusts the path to the `.node-version` file where necessary.