### PR TITLE
Add repo to FIDO spec issues

### DIFF
--- a/issues/fido-client-to-authenticator-protocol-v2.2-brokenlinks.md
+++ b/issues/fido-client-to-authenticator-protocol-v2.2-brokenlinks.md
@@ -1,6 +1,7 @@
 ---
 Title: Broken links in Client to Authenticator Protocol (CTAP)
 Tracked: Private repo, problem reported through contacts at FIDO Alliance
+Repo: https://github.com/fido-alliance/fido-2-specs
 ---
 
 While crawling [Client to Authenticator Protocol (CTAP)](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html), the following links to other specifications were detected as pointing to non-existing anchors:

--- a/issues/fido-client-to-authenticator-protocol-v2.3-brokenlinks.md
+++ b/issues/fido-client-to-authenticator-protocol-v2.3-brokenlinks.md
@@ -1,6 +1,7 @@
 ---
 Title: Broken links in Client to Authenticator Protocol (CTAP)
 Tracked: Private repo, problem reported through contacts at FIDO Alliance
+Repo: https://github.com/fido-alliance/fido-2-specs
 ---
 
 While crawling [Client to Authenticator Protocol (CTAP)](https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html), the following links to other specifications were detected as pointing to non-existing anchors:


### PR DESCRIPTION
Code that drafts the issues did not add the repo since it is private, but the rest of the code still expects to see a repo in the Markdown file.